### PR TITLE
feat: distinguish between a driver and browser | 3.0.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,4 @@
 --require spec_helper
 --color
---format RspecSonarqubeFormatter
 --out out/test-report.xml
 --format documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   dvla-lint: '.rubocop.yml'
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
 
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dvla-browser-drivers.gemspec
 gemspec
+
+gem 'bundler-audit', '~> 0.9'
+gem 'dvla-lint', '~> 1.7'
+gem 'pry', '~> 0.14'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.11'
+gem 'simplecov', '~> 0.22'
+gem 'simplecov-console', '~> 0.9'

--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Once installed, you are able to use any pre-configured browser driver from the l
 
 ### Selenium drivers
 
-| Driver           | Usage                                     |
-| ---------------- | ----------------------------------------- |
-| chrome           | `DVLA::Browser::Drivers.chrome`           |
-| headless_chrome  | `DVLA::Browser::Drivers.headless_chrome`  |
-| edge             | `DVLA::Browser::Drivers.edge`             |
-| headless_edge    | `DVLA::Browser::Drivers.headless_edge`    |
-| firefox          | `DVLA::Browser::Drivers.firefox`          |
-| headless_firefox | `DVLA::Browser::Drivers.headless_firefox` |
+| Driver                    | Usage                                              |
+|---------------------------|----------------------------------------------------|
+| selenium_chrome           | `DVLA::Browser::Drivers.selenium_chrome`           |
+| headless_selenium_chrome  | `DVLA::Browser::Drivers.headless_selenium_chrome`  |
+| selenium_edge             | `DVLA::Browser::Drivers.selenium_edge`             |
+| headless_selenium_edge    | `DVLA::Browser::Drivers.headless_selenium_edge`    |
+| selenium_firefox          | `DVLA::Browser::Drivers.selenium_firefox`          |
+| headless_selenium_firefox | `DVLA::Browser::Drivers.headless_selenium_firefox` |
 
 ### Non-selenium drivers
 
 | Driver              | Usage                                        |
-| ------------------- | -------------------------------------------- |
+|---------------------|----------------------------------------------|
 | cuprite             | `DVLA::Browser::Drivers.cuprite`             |
 | headless_cuprite    | `DVLA::Browser::Drivers.headless_cuprite`    |
 | apparition          | `DVLA::Browser::Drivers.apparition`          |
@@ -47,22 +47,22 @@ Once installed, you are able to use any pre-configured browser driver from the l
 
 ### Default configuration
 
-| Driver                | Configuration                                         |
-| --------------------- | ----------------------------------------------------- |
-| chrome, edge, firefox | --disable-dev-shm-usage<br/>                          |
-| headless\_<driver>    | --headless<br/>--no-sandbox                           |
-| cuprite, apparition   | { 'no-sandbox': nil, disable-smooth-scrolling: true } |
+| Driver                                           | Configuration                                         |
+|--------------------------------------------------|-------------------------------------------------------|
+| selenium_chrome, selenium_edge, selenium_firefox | --disable-dev-shm-usage<br/>                          |
+| headless\_<driver>                               | --headless<br/>--no-sandbox                           |
+| cuprite, apparition                              | { 'no-sandbox': nil, disable-smooth-scrolling: true } |
 
 ---
 
 ### Additional configuration
 
 | Option                                                                      | Description                                                                                                                                                                        | supported-browsers    |
-| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+|-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
 | remote: 'http://localhost:4444/wd/hub'                                      | Allows you to talk to a remote browser                                                                                                                                             | firefox               |
-| additional_options: ['window-size=1400,1920']                               | Pass additional options to the driver<br/>Supported switches: https://peter.sh/experiments/chromium-command-line-switches/                                                         | chrome, edge, firefox |
+| additional_arguments: ['window-size=1400,1920']                             | Pass additional arguments to the driver<br/>Supported switches: https://peter.sh/experiments/chromium-command-line-switches/                                                       | chrome, edge, firefox |
 | additional_preferences: [{'download.default_directory': '<download_path>'}] | Pass additional preferences to the driver<br/>Documentation: https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/Chromium/Options.html#add_preference-instance_method | chrome, edge, firefox |
-| additional_options: { 'option': value, 'option': value }                    | Pass additional options to the driver<br/>Supported switched: https://www.rubydoc.info/gems/cuprite/                                                                               | cuprite, apparition   |
+| additional_arguments: { 'option': value, 'option': value }                  | Pass additional arguments to the driver<br/>Supported switched: https://www.rubydoc.info/gems/cuprite/                                                                             | cuprite, apparition   |
 
 ## Development
 

--- a/dvla-browser-drivers.gemspec
+++ b/dvla-browser-drivers.gemspec
@@ -5,28 +5,30 @@ require_relative 'lib/dvla/browser/drivers/version'
 Gem::Specification.new do |spec|
   spec.name = 'dvla-browser-drivers'
   spec.version = DVLA::Browser::Drivers::VERSION
-  spec.authors = ['Driver and Vehicle Licensing Agency (DVLA)','Tomos Griffiths']
+  spec.authors = ['Driver and Vehicle Licensing Agency (DVLA)', 'Tomos Griffiths']
   spec.email = %w[tomos.griffiths@dvla.gov.uk]
 
-  spec.summary = 'Browser-drivers has pre-configured web-browser drivers that ' \
-                 'can be used out-of-the-box for the development of UI based applications.'
-  spec.description = 'Browser-drivers has pre-configured web-browser drivers that '                                   \
-                     'can be used out-of-the-box for the development of UI based applications. '                      \
-                     'It is built using Ruby and utilises the Capybara library (A web application testing platform) ' \
-                     'to simulate how a user interacts with the applications being tested. '                          \
-                     'It also has the facility to run Cuprite, which is a pure Ruby driver utilising Ferrum, '        \
-                     'a high level API to run headless tests.'
+  spec.summary =
+    <<~MSG
+      Browser-drivers has pre-configured web-browser drivers that can be used out-of-the-box for the development of UI based applications.
+    MSG
+
+  spec.description =
+    <<~MSG
+      Browser-drivers has pre-configured web-browser drivers that can be used out-of-the-box for the development of UI based applications.
+      It is built using Ruby and utilises the Capybara library (A web application testing platform) to simulate how a user interacts with the applications being tested.
+      It also has the facility to run Cuprite, which is a pure Ruby driver utilising Ferrum, a high level API to run headless tests.
+    MSG
+
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.1'
   spec.homepage = 'https://github.com/dvla/dvla-browser-drivers'
   if spec.respond_to?(:metadata)
-    # spec.metadata['allowed_push_host'] = 'TODO: Set to 'http://mygemserver.com''
-
     spec.metadata['homepage_uri'] = spec.homepage
     spec.metadata['source_code_uri'] = spec.homepage
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
+          'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
@@ -43,22 +45,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  # Uncomment to register a new dependency of your gem
-  spec.add_runtime_dependency 'apparition', '>= 0.6'
-  spec.add_runtime_dependency 'capybara', '>= 3.37'
-  spec.add_runtime_dependency 'cuprite', '>= 0.14'
-  spec.add_runtime_dependency 'dvla-herodotus', '>= 2.0'
-  spec.add_runtime_dependency 'selenium-webdriver', '>= 4.0'
-
-  spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'dvla-lint', '~> 1.7'
-  spec.add_development_dependency 'pry', '~> 0.14'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.11'
-  spec.add_development_dependency 'rspec-sonarqube-formatter', '~> 1.5'
-  spec.add_development_dependency 'simplecov', '~> 0.22'
-  spec.add_development_dependency 'simplecov-console', '~> 0.9'
-
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency 'apparition', '>= 0.6'
+  spec.add_dependency 'capybara', '>= 3.37'
+  spec.add_dependency 'cuprite', '>= 0.14'
+  spec.add_dependency 'dvla-herodotus', '>= 2.0'
+  spec.add_dependency 'selenium-webdriver', '>= 4.0'
 end

--- a/lib/dvla/browser/drivers.rb
+++ b/lib/dvla/browser/drivers.rb
@@ -8,6 +8,6 @@ require 'selenium-webdriver'
 
 module DVLA
   class Error < StandardError; end
-  
+
   LOG = DVLA::Herodotus.logger('browser-drivers')
 end

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,12 +1,12 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?:(?<headless>headless)_)?(?<browser>chrome|firefox|edge|cuprite|apparition)$/
+      DRIVER_REGEX = /^(?:(?<headless>headless)_)?(?<driver>(selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition))$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
-      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_options additional_preferences].freeze
-      SELENIUM_DRIVERS = %i[chrome firefox edge].freeze
+      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences].freeze
+      SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge].freeze
 
       # Creates methods in the Drivers module that matches the DRIVER_REGEX
       # These methods will register a Driver for use by Capybara in a test pack
@@ -16,13 +16,15 @@ module DVLA
       #
       # @example Driver with additional arguments
       #   DVLA::Browser::Drivers.chrome(remote: 'http://localhost:4444/wd/hub')
-      def self.method_missing(method, *args, **kwargs, &block)
+      def self.method_missing(method, *args, **kwargs, &)
         if (matches = method.match(DRIVER_REGEX))
           headless = matches[:headless].is_a? String
-          browser = matches[:browser].to_sym
+          driver = matches[:driver].to_sym
 
-          case browser
+          case driver
           when *SELENIUM_DRIVERS
+            browser = matches[:browser].to_sym
+
             kwargs.each do |key, _value|
               LOG.warn { "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" } unless SELENIUM_ACCEPTED_PARAMS.include?(key)
             end
@@ -38,18 +40,14 @@ module DVLA
 
               browser = :remote if kwargs[:remote]
 
-              if kwargs[:additional_options]
-                kwargs[:additional_options].each do |additional_option|
-                  additional_option.prepend('--') unless additional_option.start_with?('--')
-                  options.add_argument(additional_option)
-                end
+              kwargs[:additional_arguments] && kwargs[:additional_arguments].each do |argument|
+                argument.prepend('--') unless argument.start_with?('--')
+                options.add_argument(argument)
               end
 
-              if kwargs[:additional_preferences]
-                kwargs[:additional_preferences].each do |preference|
-                  key, value = preference.first
-                  options.add_preference(key, value)
-                end
+              kwargs[:additional_preferences] && kwargs[:additional_preferences].each do |preference|
+                key, value = preference.first
+                options.add_preference(key, value)
               end
 
               ::Capybara::Selenium::Driver.new(app, url: kwargs[:remote], browser:, options:)
@@ -60,7 +58,7 @@ module DVLA
             end
 
             ::Capybara.register_driver method do |app|
-              Object.const_get("Capybara::#{browser.to_s.capitalize}::Driver").new(
+              Object.const_get("Capybara::#{driver.to_s.capitalize}::Driver").new(
                 app,
                 headless:,
                 timeout: kwargs[:timeout] || 30,
@@ -69,11 +67,13 @@ module DVLA
             end
           end
 
-          LOG.info("Driver set to: '#{method}'")
+          LOG.info { "Driver set to: '#{method}'" }
+
+          ::Capybara.javascript_driver = method
           ::Capybara.default_driver = method
           ::Capybara.current_driver = method
         else
-          super.method_missing(method, *args, &block)
+          super.method_missing(method, *args, &)
         end
       end
 

--- a/lib/dvla/browser/drivers/version.rb
+++ b/lib/dvla/browser/drivers/version.rb
@@ -3,7 +3,7 @@
 module DVLA
   module Browser
     module Drivers
-      VERSION = '2.3.0'
+      VERSION = '3.0.0'
     end
   end
 end

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe DVLA::Browser::Drivers do
   end
 
   it 'can create a chrome driver' do
-    DVLA::Browser::Drivers.chrome
-    expect(Capybara.current_driver).to eq(:chrome)
+    DVLA::Browser::Drivers.selenium_chrome
+    expect(Capybara.current_driver).to eq(:selenium_chrome)
   end
 
   it 'can create a firefox driver' do
-    DVLA::Browser::Drivers.firefox
-    expect(Capybara.current_driver).to eq(:firefox)
+    DVLA::Browser::Drivers.selenium_firefox
+    expect(Capybara.current_driver).to eq(:selenium_firefox)
   end
 
   it 'can create an edge driver' do
-    DVLA::Browser::Drivers.edge
-    expect(Capybara.current_driver).to eq(:edge)
+    DVLA::Browser::Drivers.selenium_edge
+    expect(Capybara.current_driver).to eq(:selenium_edge)
   end
 
   it 'can create a cuprite driver' do
@@ -29,8 +29,8 @@ RSpec.describe DVLA::Browser::Drivers do
   end
 
   it 'can create a headless chrome driver with standard options' do
-    DVLA::Browser::Drivers.headless_chrome
-    expect(Capybara.current_driver).to eq(:headless_chrome)
+    DVLA::Browser::Drivers.headless_selenium_chrome
+    expect(Capybara.current_driver).to eq(:headless_selenium_chrome)
 
     args = Capybara.current_session.driver.options[:options].options[:args]
 
@@ -40,13 +40,13 @@ RSpec.describe DVLA::Browser::Drivers do
   end
 
   it 'can create a headless firefox driver' do
-    DVLA::Browser::Drivers.headless_firefox
-    expect(Capybara.current_driver).to eq(:headless_firefox)
+    DVLA::Browser::Drivers.headless_selenium_firefox
+    expect(Capybara.current_driver).to eq(:headless_selenium_firefox)
   end
 
   it 'can create a headless edge driver' do
-    DVLA::Browser::Drivers.headless_edge
-    expect(Capybara.current_driver).to eq(:headless_edge)
+    DVLA::Browser::Drivers.headless_selenium_edge
+    expect(Capybara.current_driver).to eq(:headless_selenium_edge)
   end
 
   it 'can create a headless apparition driver' do
@@ -66,12 +66,15 @@ RSpec.describe DVLA::Browser::Drivers do
   end
 
   it 'allows additional args to be passed' do
-    DVLA::Browser::Drivers.chrome(remote: 'hello_world')
+    DVLA::Browser::Drivers.selenium_chrome(remote: 'hello_world')
     expect(Capybara.current_session.driver.options[:url]).to eq('hello_world')
     expect(Capybara.current_session.driver.options[:browser]).to eq(:remote)
 
-    DVLA::Browser::Drivers.firefox(additional_options: %w[headless])
+    DVLA::Browser::Drivers.selenium_firefox(additional_arguments: %w[headless])
     expect(Capybara.current_session.driver.options[:options].options[:args]).to include('--headless')
+
+    DVLA::Browser::Drivers.selenium_edge(additional_preferences: [{ key: 'value' }])
+    expect(Capybara.current_session.driver.options[:options].prefs).to include({ key: 'value' })
 
     DVLA::Browser::Drivers.cuprite(timeout: 5)
     expect(Capybara.current_session.driver.options[:timeout]).to eq(5)
@@ -82,15 +85,15 @@ RSpec.describe DVLA::Browser::Drivers do
   end
 
   it 'responds to method that matches regex' do
-    expect(DVLA::Browser::Drivers.respond_to?(:chrome)).to be true
-    expect(DVLA::Browser::Drivers.respond_to?(:edge)).to be true
-    expect(DVLA::Browser::Drivers.respond_to?(:firefox)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:selenium_chrome)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:selenium_edge)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:selenium_firefox)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:cuprite)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:apparition)).to be true
 
-    expect(DVLA::Browser::Drivers.respond_to?(:headless_chrome)).to be true
-    expect(DVLA::Browser::Drivers.respond_to?(:headless_edge)).to be true
-    expect(DVLA::Browser::Drivers.respond_to?(:headless_firefox)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_chrome)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_edge)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_firefox)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:headless_cuprite)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:headless_apparition)).to be true
   end


### PR DESCRIPTION
**Breaking changes**
* chrome, firefox and edge are no longer supported. These need to be prefixed with selenium.
* additional_options is now additional_arguments to align terminology.

**What's new**
* Capybara.javascript_driver is now being set.