### PR TITLE
Enable Selenium Safari & binary override

### DIFF
--- a/.github/workflows/gem-test.yml
+++ b/.github/workflows/gem-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [3.1.1] - 2025-12-12
+
+- Add selenium_safari config
+- Add optional binary string for Selenium 
 
 # [3.1.0] - 2025-12-10
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Once installed, you are able to use any pre-configured browser driver from the l
 |---------------------------|----------------------------------------------------|
 | selenium_chrome           | `DVLA::Browser::Drivers.selenium_chrome`           |
 | headless_selenium_chrome  | `DVLA::Browser::Drivers.headless_selenium_chrome`  |
-| selenium_edge             | `DVLA::Browser::Drivers.selenium_edge`             |
-| headless_selenium_edge    | `DVLA::Browser::Drivers.headless_selenium_edge`    |
 | selenium_firefox          | `DVLA::Browser::Drivers.selenium_firefox`          |
 | headless_selenium_firefox | `DVLA::Browser::Drivers.headless_selenium_firefox` |
+| selenium_edge             | `DVLA::Browser::Drivers.selenium_edge`             |
+| selenium_safari           | `DVLA::Browser::Drivers.selenium_safari`           |
 
 ### Non-selenium drivers
 
@@ -42,6 +42,8 @@ Once installed, you are able to use any pre-configured browser driver from the l
 | headless_cuprite    | `DVLA::Browser::Drivers.headless_cuprite`    |
 | apparition          | `DVLA::Browser::Drivers.apparition`          |
 | headless_apparition | `DVLA::Browser::Drivers.headless_apparition` |
+
+**Note:** Safari and Edge do not support headless mode. 
 
 ---
 

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,7 +1,7 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?:(?<headless>headless)_(?<driver>selenium_(?<browser>chrome|firefox)|cuprite|apparition)|(?<driver>selenium_(?<browser>chrome|firefox|edge|safari)|cuprite|apparition))$/
+      DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox)|cuprite|apparition)|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition))$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
@@ -19,11 +19,12 @@ module DVLA
       def self.method_missing(method, *args, **kwargs, &)
         if (matches = method.match(DRIVER_REGEX))
           headless = matches[:headless].is_a? String
-          driver = matches[:driver].to_sym
+          driver = matches[:driver]&.to_sym || matches[:driver_no_headless]&.to_sym
+          browser_match = matches[:browser] || matches[:browser_no_headless]
 
           case driver
           when *SELENIUM_DRIVERS
-            browser = matches[:browser].to_sym
+            browser = browser_match.to_sym
 
             kwargs.each do |key, _value|
               LOG.warn { "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" } unless SELENIUM_ACCEPTED_PARAMS.include?(key)

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,7 +1,7 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?:(?<headless>headless)_)?(?<driver>(selenium_(?<browser>chrome|firefox|edge|safari)|cuprite|apparition))$/
+      DRIVER_REGEX = /^(?:(?<headless>headless)_(?<driver>selenium_(?<browser>chrome|firefox)|cuprite|apparition)|(?<driver>selenium_(?<browser>chrome|firefox|edge|safari)|cuprite|apparition))$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
@@ -24,11 +24,6 @@ module DVLA
           case driver
           when *SELENIUM_DRIVERS
             browser = matches[:browser].to_sym
-            
-            if headless && %i[safari edge].include?(browser)
-              LOG.warn { "#{browser.capitalize} does not support headless mode".red.bold }
-              headless = false
-            end
 
             kwargs.each do |key, _value|
               LOG.warn { "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" } unless SELENIUM_ACCEPTED_PARAMS.include?(key)

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -24,6 +24,11 @@ module DVLA
           case driver
           when *SELENIUM_DRIVERS
             browser = matches[:browser].to_sym
+            
+            if headless && %i[safari edge].include?(browser)
+              LOG.warn { "#{browser.capitalize} does not support headless mode".red.bold }
+              headless = false
+            end
 
             kwargs.each do |key, _value|
               LOG.warn { "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" } unless SELENIUM_ACCEPTED_PARAMS.include?(key)

--- a/lib/dvla/browser/drivers/version.rb
+++ b/lib/dvla/browser/drivers/version.rb
@@ -3,7 +3,7 @@
 module DVLA
   module Browser
     module Drivers
-      VERSION = '3.1.0'
+      VERSION = '3.1.1'
     end
   end
 end

--- a/spec/dvla/browser/drivers_bidi_spec.rb
+++ b/spec/dvla/browser/drivers_bidi_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe 'DVLA::Browser::Drivers BiDi Support' do
   %i[headless_selenium_chrome headless_selenium_firefox selenium_edge].each do |driver|
     describe "BiDi functionality with #{driver}", :bidi_integration do
-      skip 'Edge WebDriver not available in CI' if driver == :selenium_edge && ENV['CI']
       before do
+        skip 'Edge WebDriver not available in CI' if driver == :selenium_edge && ENV['CI']
         DVLA::Browser::Drivers.send(driver)
         Capybara.current_driver = driver
       end

--- a/spec/dvla/browser/drivers_bidi_spec.rb
+++ b/spec/dvla/browser/drivers_bidi_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe 'DVLA::Browser::Drivers BiDi Support' do
   %i[headless_selenium_chrome headless_selenium_firefox selenium_edge].each do |driver|
     describe "BiDi functionality with #{driver}", :bidi_integration do
+      skip 'Edge WebDriver not available in CI' if driver == :selenium_edge && ENV['CI']
       before do
         DVLA::Browser::Drivers.send(driver)
         Capybara.current_driver = driver

--- a/spec/dvla/browser/drivers_bidi_spec.rb
+++ b/spec/dvla/browser/drivers_bidi_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'DVLA::Browser::Drivers BiDi Support' do
-  %i[headless_selenium_chrome headless_selenium_firefox headless_selenium_edge].each do |driver|
+  %i[headless_selenium_chrome headless_selenium_firefox selenium_edge].each do |driver|
     describe "BiDi functionality with #{driver}", :bidi_integration do
       before do
         DVLA::Browser::Drivers.send(driver)

--- a/spec/dvla/browser/drivers_bidi_spec.rb
+++ b/spec/dvla/browser/drivers_bidi_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'DVLA::Browser::Drivers BiDi Support' do
 
       after do
         Capybara.reset_sessions!
+        Capybara.instance_variable_set(:@session_pool, nil)
       end
 
       it 'provides BiDi instance by default' do

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe DVLA::Browser::Drivers do
   after do
     Capybara.reset_sessions!
+    Capybara.instance_variable_set(:@session_pool, nil)
   end
 
   it 'has a version number' do
@@ -77,17 +78,23 @@ RSpec.describe DVLA::Browser::Drivers do
     expect(options.dig(:browser_options, :'disable-smooth-scrolling')).to eq(true)
   end
 
-  it 'allows additional args to be passed' do
+  it 'allows Chrome to accept remote argument' do
     DVLA::Browser::Drivers.selenium_chrome(remote: 'hello_world')
     expect(Capybara.current_session.driver.options[:url]).to eq('hello_world')
     expect(Capybara.current_session.driver.options[:browser]).to eq(:remote)
+  end
 
+  it 'allows Firefox to accept additional arguments' do
     DVLA::Browser::Drivers.selenium_firefox(additional_arguments: %w[headless])
     expect(Capybara.current_session.driver.options[:options].options[:args]).to include('--headless')
+  end
 
+  it 'allows Edge to accept additional preferences' do
     DVLA::Browser::Drivers.selenium_edge(additional_preferences: [{ key: 'value' }])
     expect(Capybara.current_session.driver.options[:options].prefs).to include({ key: 'value' })
+  end
 
+  it 'allows Cuprite to accept timeout and browser options' do
     DVLA::Browser::Drivers.cuprite(timeout: 5, browser_options: { something: 'blah' })
     expect(Capybara.current_session.driver.options.dig(:browser_options, :something)).to eq('blah')
   end

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe DVLA::Browser::Drivers do
+  after do
+    Capybara.reset_sessions!
+  end
+
   it 'has a version number' do
     expect(DVLA::Browser::Drivers::VERSION).not_to be nil
   end
@@ -49,14 +53,12 @@ RSpec.describe DVLA::Browser::Drivers do
     expect(Capybara.current_driver).to eq(:headless_selenium_firefox)
   end
 
-  it 'warns the user creating an Edge driver with headless configuration' do
-    expect { DVLA::Browser::Drivers.headless_selenium_edge }.to output(/Edge does not support headless mode/).to_stdout_from_any_process
-    expect(Capybara.current_driver).to eq(:headless_selenium_edge)
+  it 'does not create an Edge driver with headless configuration' do
+    expect { DVLA::Browser::Drivers.headless_selenium_edge }.to raise_error NoMethodError
   end
 
-  it 'warns the user creating a Safari driver with headless configuration' do
-    expect { DVLA::Browser::Drivers.headless_selenium_safari }.to output(/Safari does not support headless mode/).to_stdout_from_any_process
-    expect(Capybara.current_driver).to eq(:headless_selenium_safari)
+  it 'does not create a Safari driver with headless configuration' do
+    expect { DVLA::Browser::Drivers.headless_selenium_safari }.to raise_error NoMethodError
   end
 
   it 'can create a headless Apparition driver' do
@@ -98,13 +100,16 @@ RSpec.describe DVLA::Browser::Drivers do
     expect(DVLA::Browser::Drivers.respond_to?(:selenium_chrome)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:selenium_edge)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:selenium_firefox)).to be true
+    expect(DVLA::Browser::Drivers.respond_to?(:selenium_safari)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:cuprite)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:apparition)).to be true
 
     expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_chrome)).to be true
-    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_edge)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_firefox)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:headless_cuprite)).to be true
     expect(DVLA::Browser::Drivers.respond_to?(:headless_apparition)).to be true
+
+    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_edge)).to be false
+    expect(DVLA::Browser::Drivers.respond_to?(:headless_selenium_safari)).to be false
   end
 end

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -3,32 +3,37 @@ RSpec.describe DVLA::Browser::Drivers do
     expect(DVLA::Browser::Drivers::VERSION).not_to be nil
   end
 
-  it 'can create a chrome driver' do
+  it 'can create a Chrome driver' do
     DVLA::Browser::Drivers.selenium_chrome
     expect(Capybara.current_driver).to eq(:selenium_chrome)
   end
 
-  it 'can create a firefox driver' do
+  it 'can create a Firefox driver' do
     DVLA::Browser::Drivers.selenium_firefox
     expect(Capybara.current_driver).to eq(:selenium_firefox)
   end
 
-  it 'can create an edge driver' do
+  it 'can create an Edge driver' do
     DVLA::Browser::Drivers.selenium_edge
     expect(Capybara.current_driver).to eq(:selenium_edge)
   end
 
-  it 'can create a cuprite driver' do
+  it 'can create a Safari driver' do
+    DVLA::Browser::Drivers.selenium_safari
+    expect(Capybara.current_driver).to eq(:selenium_safari)
+  end
+
+  it 'can create a Cuprite driver' do
     DVLA::Browser::Drivers.cuprite
     expect(Capybara.current_driver).to eq(:cuprite)
   end
 
-  it 'can create an apparition driver' do
+  it 'can create an Apparition driver' do
     DVLA::Browser::Drivers.apparition
     expect(Capybara.current_driver).to eq(:apparition)
   end
 
-  it 'can create a headless chrome driver with standard options' do
+  it 'can create a headless Chrome driver with standard options' do
     DVLA::Browser::Drivers.headless_selenium_chrome
     expect(Capybara.current_driver).to eq(:headless_selenium_chrome)
 
@@ -39,22 +44,27 @@ RSpec.describe DVLA::Browser::Drivers do
     expect(args).to include('--no-sandbox')
   end
 
-  it 'can create a headless firefox driver' do
+  it 'can create a headless Firefox driver' do
     DVLA::Browser::Drivers.headless_selenium_firefox
     expect(Capybara.current_driver).to eq(:headless_selenium_firefox)
   end
 
-  it 'can create a headless edge driver' do
-    DVLA::Browser::Drivers.headless_selenium_edge
+  it 'warns the user creating an Edge driver with headless configuration' do
+    expect { DVLA::Browser::Drivers.headless_selenium_edge }.to output(/Edge does not support headless mode/).to_stdout_from_any_process
     expect(Capybara.current_driver).to eq(:headless_selenium_edge)
   end
 
-  it 'can create a headless apparition driver' do
+  it 'warns the user creating a Safari driver with headless configuration' do
+    expect { DVLA::Browser::Drivers.headless_selenium_safari }.to output(/Safari does not support headless mode/).to_stdout_from_any_process
+    expect(Capybara.current_driver).to eq(:headless_selenium_safari)
+  end
+
+  it 'can create a headless Apparition driver' do
     DVLA::Browser::Drivers.headless_apparition
     expect(Capybara.current_driver).to eq(:headless_apparition)
   end
 
-  it 'can create a headless cuprite driver with standard options' do
+  it 'can create a headless Cuprite driver with standard options' do
     DVLA::Browser::Drivers.headless_cuprite
     expect(Capybara.current_driver).to eq(:headless_cuprite)
 


### PR DESCRIPTION
Adding config to allow selenium_safari

`DVLA::Browser::Drivers.selenium_safari`

Optional 'binary' arg to point to chrome based browsers.
`DVLA::Browser::Drivers.selenium_chrome(binary: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser')`