### PR TITLE
allow window_size param during browser registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,16 @@ Modifiers can be combined, e.g. `headless_selenium_firefox_no_js_proxied`
 [Cuprite Documentation](https://www.rubydoc.info/gems/cuprite/)
 [Selenium Additional Preferences Documentation](https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/Chromium/Options.html#add_preference-instance_method)
 
-| Option                 | Driver                        | Usage                                                                                           | Description                                |
-|------------------------|-------------------------------|-------------------------------------------------------------------------------------------------|--------------------------------------------|
-| remote                 | Selenium, Cuprite, Apparition | `selenium_chrome(remote: 'http://localhost:4444/wd/hub')`                                       | Allows you to talk to a remote browser     |
-| additional_arguments   | Selenium                      | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
-| additional_preferences | Selenium                      | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
-| proxy                  | Selenium, Cuprite             | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
-| timeout                | Cuprite, Apparition           | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
-| save_path              | Cuprite, Apparition           | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
-| browser_options        | Cuprite, Apparition           | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
+| Option                 | Driver                               | Usage                                                                                           | Description                                |
+|------------------------|--------------------------------------|-------------------------------------------------------------------------------------------------|--------------------------------------------|
+| remote                 | Selenium, Cuprite, Apparition        | `selenium_chrome(remote: 'http://localhost:4444/wd/hub')`                                       | Allows you to talk to a remote browser     |
+| additional_arguments   | Selenium                             | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
+| additional_preferences | Selenium                             | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
+| proxy                  | Selenium, Cuprite                    | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
+| window_size            | Chrome, Firefox, Cuprite, Apparition | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Edge or Safari |
+| timeout                | Cuprite, Apparition                  | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
+| save_path              | Cuprite, Apparition                  | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
+| browser_options        | Cuprite, Apparition                  | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
 
 ---
 

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -3,9 +3,9 @@ module DVLA
     module Drivers
       DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition)(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition)(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
 
-      OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy].freeze
+      OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
-      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy].freeze
+      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
       # Creates methods in the Drivers module that matches the DRIVER_REGEX
@@ -35,6 +35,8 @@ module DVLA
             kwargs.each do |key, _value|
               puts "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" unless SELENIUM_ACCEPTED_PARAMS.include?(key)
             end
+
+            puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari edge].include?(browser)
 
             ::Capybara.register_driver method do |app|
               if browser == :safari
@@ -67,6 +69,11 @@ module DVLA
                   end
                 end
 
+                if kwargs[:window_size] && !%i[firefox edge].include?(browser)
+                  size = parse_window_size(kwargs[:window_size])
+                  options.add_argument("--window-size=#{size[0]},#{size[1]}")
+                end
+
                 kwargs[:additional_arguments] && kwargs[:additional_arguments].each do |argument|
                   argument.prepend('--') unless argument.start_with?('--')
                   options.add_argument(argument)
@@ -92,6 +99,11 @@ module DVLA
 
               ::Capybara::Selenium::Driver.new(app, **driver_options).tap do |driver|
                 driver.browser.execute_cdp('Emulation.setScriptExecutionDisabled', value: true) if no_js && browser == :edge
+                if kwargs[:window_size] && browser == :firefox
+                  size = parse_window_size(kwargs[:window_size])
+                  driver.browser.manage.window.resize_to(size[0], size[1])
+                end
+
               end
             end
           else
@@ -101,6 +113,7 @@ module DVLA
 
             browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
             browser_options = browser_options.merge(kwargs[:browser_options]) if kwargs[:browser_options]
+            browser_options[:'window-size'] = kwargs[:window_size] if kwargs[:window_size]
             browser_options[:'blink-settings'] = 'scriptEnabled=false' if no_js
 
             if kwargs[:proxy]
@@ -116,7 +129,12 @@ module DVLA
                 browser_options:,
                 save_path: kwargs[:save_path],
                 url: kwargs[:remote],
-                )
+                ).tap do |driver|
+                if kwargs[:window_size]
+                  size = parse_window_size(kwargs[:window_size])
+                  driver.browser.resize(width: size[0], height: size[1])
+                end
+              end
             end
           end
 
@@ -133,6 +151,11 @@ module DVLA
       def self.respond_to_missing?(method, *args)
         method.match(DRIVER_REGEX) || super
       end
+
+      def self.parse_window_size(window_size)
+        window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)
+      end
+      private_class_method :parse_window_size
     end
   end
 end

--- a/lib/dvla/browser/drivers/version.rb
+++ b/lib/dvla/browser/drivers/version.rb
@@ -3,7 +3,7 @@
 module DVLA
   module Browser
     module Drivers
-      VERSION = '3.2.0'
+      VERSION = '3.3.0'
     end
   end
 end


### PR DESCRIPTION
Allows you to pass the window_size in during registration
It accepts either a string or array of values
`999x999` or `[999,999]`

Works on Cuprite, Selenium Chrome & Selenium Firefox.
Firefox is slightly different as it needs to open and then resize. 