### PR TITLE
Add device emulation configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'rake', '~> 13.3'
 gem 'rspec', '~> 3.13'
 gem 'simplecov', '~> 0.22'
 gem 'simplecov-console', '~> 0.9'
+
+gem "irb", "~> 1.18"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Modifiers can be combined, e.g. `headless_selenium_firefox_no_js_proxied`
 | additional_arguments   | Selenium                             | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
 | additional_preferences | Selenium                             | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
 | proxy                  | Selenium, Cuprite                    | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
-| window_size            | Chrome, Firefox, Cuprite, Apparition | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Edge or Safari |
+| window_size            | Chrome, Edge, Cuprite, Apparition    | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Firefox, Edge or Safari |
 | timeout                | Cuprite, Apparition                  | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
 | save_path              | Cuprite, Apparition                  | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
 | browser_options        | Cuprite, Apparition                  | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
@@ -93,6 +93,33 @@ It is still in active development so breaking changes are expected. Check the do
 * [Selenium docs](https://www.selenium.dev/documentation/webdriver/bidi/)
 * [W3C specification](https://w3c.github.io/webdriver-bidi/)
 
+
+## Rake Tasks
+
+The gem ships with a set of rake tasks to quickly launch any driver against a URL for manual inspection.
+Add the following to your `Rakefile` to make them available:
+
+```ruby
+require 'dvla/browser/drivers/tasks'
+```
+
+Then run any `browser:*` task, e.g.:
+
+```bash
+bundle exec rake browser:selenium_chrome
+bundle exec rake browser:headless_cuprite
+```
+
+The following environment variables can be used to configure the tasks:
+
+| Variable            | Default                  | Description                              |
+|---------------------|--------------------------|------------------------------------------|
+| `BROWSER_URL`       | `http://localhost:3000`  | URL the browser will open                |
+| `PROXY_URL`         | `http://localhost:8080`  | Proxy URL for `_proxied` tasks           |
+| `BROWSER_OPEN_TIME` | `10`                     | Seconds to hold the browser open         |
+| `BROWSER_WINDOW_SIZE` | `1337x800`             | Window size for `_window_size` tasks     |
+
+---
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,16 @@ Modifiers can be combined, e.g. `headless_selenium_firefox_no_js_proxied`
 [Cuprite Documentation](https://www.rubydoc.info/gems/cuprite/)
 [Selenium Additional Preferences Documentation](https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/Chromium/Options.html#add_preference-instance_method)
 
-| Option                 | Driver                        | Usage                                                                                           | Description                                |
-|------------------------|-------------------------------|-------------------------------------------------------------------------------------------------|--------------------------------------------|
-| remote                 | Selenium, Cuprite, Apparition | `selenium_chrome(remote: 'http://localhost:4444/wd/hub')`                                       | Allows you to talk to a remote browser     |
-| additional_arguments   | Selenium                      | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
-| additional_preferences | Selenium                      | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
-| proxy                  | Selenium, Cuprite             | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
-| timeout                | Cuprite, Apparition           | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
-| save_path              | Cuprite, Apparition           | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
-| browser_options        | Cuprite, Apparition           | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
+| Option                 | Driver                               | Usage                                                                                           | Description                                |
+|------------------------|--------------------------------------|-------------------------------------------------------------------------------------------------|--------------------------------------------|
+| remote                 | Selenium, Cuprite, Apparition        | `selenium_chrome(remote: 'http://localhost:4444/wd/hub')`                                       | Allows you to talk to a remote browser     |
+| additional_arguments   | Selenium                             | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
+| additional_preferences | Selenium                             | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
+| proxy                  | Selenium, Cuprite                    | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
+| window_size            | Chrome, Firefox, Cuprite, Apparition | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Edge or Safari |
+| timeout                | Cuprite, Apparition                  | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
+| save_path              | Cuprite, Apparition                  | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
+| browser_options        | Cuprite, Apparition                  | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,48 @@ Modifiers can be combined, e.g. `headless_selenium_firefox_no_js_proxied`
 | additional_arguments   | Selenium                             | `selenium_chrome(additional_arguments: ['window-size=1400,1920'] `                              | Pass additional arguments to the driver    |
 | additional_preferences | Selenium                             | `selenium_chrome(additional_preferences: [{'download.default_directory': '<download_path>'}] )` | Pass additional preferences to the driver  |
 | proxy                  | Selenium, Cuprite                    | `selenium_firefox_proxied(proxy: 'http://proxy:8080')`                                          | Sets the proxy URL for proxied drivers     |
-| window_size            | Chrome, Edge, Cuprite, Apparition    | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Firefox, Edge or Safari |
+| window_size            | Chrome, Edge, Cuprite, Apparition    | `selenium_chrome(window_size: [1400, 900])`                                                     | Sets the browser window size. Accepts an array `[w, h]` or a string `'1400x900'`. Not supported on Firefox or Safari. Overridden by `emulate_device` |
+| emulate_device         | Chrome, Edge                         | `selenium_chrome(emulate_device: :iphone_15)`                                                   | Emulates a mobile device. Accepts a symbol matching a built-in profile (see [Mobile emulation](#mobile-emulation)) or a custom hash |
 | timeout                | Cuprite, Apparition                  | `cuprite(timeout: 60 )`                                                                         | Sets the default timeout for the driver    |
 | save_path              | Cuprite, Apparition                  | `cuprite(save_path: 'File.expand_path('./somewhere')' )`                                        | Tells the browser where to store downloads |
 | browser_options        | Cuprite, Apparition                  | `cuprite(browser_options: { option: value, option: value })`                                    | Pass additional options to the browser     |
+
+---
+
+### Mobile emulation
+
+The `emulate_device` option sets device metrics (width, height, pixel ratio, touch) and the user agent string via Chrome's emulation API.
+
+Pass a symbol to match one of the built-in profiles from `DVLA::Browser::Drivers::MOBILE_PROFILES`:
+
+```ruby
+DVLA::Browser::Drivers.selenium_chrome(emulate_device: :iphone_15)
+DVLA::Browser::Drivers.headless_selenium_chrome(emulate_device: :ipad_pro)
+DVLA::Browser::Drivers.selenium_chrome(emulate_device: :galaxy_s9_plus_landscape)
+```
+
+Or pass a custom hash using [Chrome emulation keys](https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/Chromium/Options.html#add_emulation-instance_method):
+
+```ruby
+DVLA::Browser::Drivers.selenium_chrome(
+  emulate_device: {
+    device_metrics: { width: 390, height: 844, pixelRatio: 3.0, touch: true },
+    user_agent: 'Mozilla/5.0 (custom)'
+  }
+)
+```
+
+Available built-in profile symbols follow the naming pattern `<device_name>` or `<device_name>_landscape`, e.g.:
+
+| Symbol | Dimensions |
+|--------|------------|
+| `:iphone_15` | 393×659 |
+| `:iphone_15_landscape` | 734×343 |
+| `:ipad_pro` | 1024×1366 |
+| `:pixel_5` | 393×851 |
+| `:galaxy_s9_plus` | 320×658 |
+
+See `lib/dvla/browser/drivers/mobile_profiles.rb` for the full list.
 
 ---
 
@@ -103,21 +141,25 @@ Add the following to your `Rakefile` to make them available:
 require 'dvla/browser/drivers/tasks'
 ```
 
-Then run any `browser:*` task, e.g.:
+Tasks are namespaced by browser. Run any `browser:<browser>:<variant>` task, e.g.:
 
 ```bash
-bundle exec rake browser:selenium_chrome
-bundle exec rake browser:headless_cuprite
+bundle exec rake browser:chrome
+bundle exec rake browser:chrome:headless
+bundle exec rake browser:chrome:headless_no_js
+bundle exec rake browser:chrome:window_size
+bundle exec rake browser:chrome:emulated
+bundle exec rake browser:cuprite:headless
 ```
 
 The following environment variables can be used to configure the tasks:
 
-| Variable            | Default                  | Description                              |
-|---------------------|--------------------------|------------------------------------------|
-| `BROWSER_URL`       | `http://localhost:3000`  | URL the browser will open                |
-| `PROXY_URL`         | `http://localhost:8080`  | Proxy URL for `_proxied` tasks           |
-| `BROWSER_OPEN_TIME` | `10`                     | Seconds to hold the browser open         |
-| `BROWSER_WINDOW_SIZE` | `1337x800`             | Window size for `_window_size` tasks     |
+| Variable              | Default                  | Description                                    |
+|-----------------------|--------------------------|------------------------------------------------|
+| `BROWSER_URL`         | `http://localhost:3000`  | URL the browser will open                      |
+| `PROXY_URL`           | `http://localhost:8080`  | Proxy URL for `proxied` tasks                  |
+| `BROWSER_OPEN_TIME`   | `10`                     | Seconds to hold the browser open               |
+| `BROWSER_WINDOW_SIZE` | `1337x800`               | Window size for `window_size` tasks            |
 
 ---
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+require 'dvla/browser/drivers/tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/dvla-browser-drivers.gemspec
+++ b/dvla-browser-drivers.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").select do |f|
       f.match(/\A(?:lib|bin|exe)/) ||
-        f.match(/.(?:gemspec|md|ruby-version)\Z/) ||
+        f.match(/.(?:gemspec|md|rake|ruby-version)\Z/) ||
         f.match(/\AGemfile\Z/)
     end
   end

--- a/dvla-browser-drivers.gemspec
+++ b/dvla-browser-drivers.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'apparition', '>= 0.6'
   spec.add_dependency 'capybara', '>= 3.37'
-  spec.add_dependency 'capybara-playwright-driver', '>= 0.5'
   spec.add_dependency 'cuprite', '>= 0.14'
   spec.add_dependency 'selenium-webdriver', '>= 4.0'
 end

--- a/dvla-browser-drivers.gemspec
+++ b/dvla-browser-drivers.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'apparition', '>= 0.6'
   spec.add_dependency 'capybara', '>= 3.37'
+  spec.add_dependency 'capybara-playwright-driver', '>= 0.5'
   spec.add_dependency 'cuprite', '>= 0.14'
   spec.add_dependency 'selenium-webdriver', '>= 4.0'
 end

--- a/lib/dvla/browser/drivers.rb
+++ b/lib/dvla/browser/drivers.rb
@@ -1,3 +1,4 @@
+require_relative 'drivers/mobile_profiles'
 require_relative 'drivers/meta_drivers'
 require_relative 'drivers/version'
 

--- a/lib/dvla/browser/drivers.rb
+++ b/lib/dvla/browser/drivers.rb
@@ -4,6 +4,7 @@ require_relative 'drivers/version'
 
 require 'capybara/apparition'
 require 'capybara/cuprite'
+require 'capybara-playwright-driver'
 require 'selenium-webdriver'
 
 module DVLA

--- a/lib/dvla/browser/drivers.rb
+++ b/lib/dvla/browser/drivers.rb
@@ -4,7 +4,6 @@ require_relative 'drivers/version'
 
 require 'capybara/apparition'
 require 'capybara/cuprite'
-require 'capybara-playwright-driver'
 require 'selenium-webdriver'
 
 module DVLA

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -5,7 +5,7 @@ module DVLA
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
-      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size].freeze
+      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size mobile_emulation].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
       # Creates methods in the Drivers module that matches the DRIVER_REGEX
@@ -36,7 +36,7 @@ module DVLA
               puts "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" unless SELENIUM_ACCEPTED_PARAMS.include?(key)
             end
 
-            puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari edge].include?(browser)
+            puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari].include?(browser)
 
             ::Capybara.register_driver method do |app|
               if browser == :safari
@@ -69,9 +69,15 @@ module DVLA
                   end
                 end
 
-                if kwargs[:window_size] && !%i[firefox edge].include?(browser)
+                if kwargs[:window_size] && %i[chrome edge].include?(browser)
                   size = parse_window_size(kwargs[:window_size])
                   options.add_argument("--window-size=#{size[0]},#{size[1]}")
+                end
+
+                if kwargs[:mobile_emulation] && %i[chrome edge].include?(browser)
+                  puts 'Warning: window_size will be overridden by mobile_emulation' if kwargs[:window_size]
+                  emulation = resolve_mobile_emulation(kwargs[:mobile_emulation])
+                  options.add_emulation(**emulation)
                 end
 
                 kwargs[:additional_arguments] && kwargs[:additional_arguments].each do |argument|
@@ -103,7 +109,6 @@ module DVLA
                   size = parse_window_size(kwargs[:window_size])
                   driver.browser.manage.window.resize_to(size[0], size[1])
                 end
-
               end
             end
           else
@@ -113,7 +118,6 @@ module DVLA
 
             browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
             browser_options = browser_options.merge(kwargs[:browser_options]) if kwargs[:browser_options]
-            browser_options[:'window-size'] = kwargs[:window_size] if kwargs[:window_size]
             browser_options[:'blink-settings'] = 'scriptEnabled=false' if no_js
 
             if kwargs[:proxy]
@@ -153,9 +157,24 @@ module DVLA
       end
 
       def self.parse_window_size(window_size)
-        window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)
+        size = window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)
+        raise ArgumentError, "window_size must have exactly 2 elements [width, height], got: #{window_size.inspect}" unless size.length == 2
+
+        size
       end
       private_class_method :parse_window_size
+
+      def self.resolve_mobile_emulation(mobile_emulation)
+        if mobile_emulation.is_a?(Symbol)
+          device_name = MOBILE_PROFILES[mobile_emulation]
+          raise ArgumentError, "Unknown mobile profile: ':#{mobile_emulation}'. Available: #{MOBILE_PROFILES.keys.map { |k| ":#{k}" }.join(', ')}" unless device_name
+
+          { device_name: }
+        else
+          mobile_emulation.transform_keys(&:to_sym)
+        end
+      end
+      private_class_method :resolve_mobile_emulation
     end
   end
 end

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -3,9 +3,9 @@ module DVLA
     module Drivers
       DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition)(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition)(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
 
-      OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy].freeze
+      OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
-      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy].freeze
+      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
       # Creates methods in the Drivers module that matches the DRIVER_REGEX
@@ -35,6 +35,8 @@ module DVLA
             kwargs.each do |key, _value|
               puts "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" unless SELENIUM_ACCEPTED_PARAMS.include?(key)
             end
+
+            puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari edge].include?(browser)
 
             ::Capybara.register_driver method do |app|
               if browser == :safari
@@ -67,6 +69,11 @@ module DVLA
                   end
                 end
 
+                if kwargs[:window_size] && !%i[firefox edge].include?(browser)
+                  size = parse_window_size(kwargs[:window_size])
+                  options.add_argument("--window-size=#{size[0]},#{size[1]}")
+                end
+
                 kwargs[:additional_arguments] && kwargs[:additional_arguments].each do |argument|
                   argument.prepend('--') unless argument.start_with?('--')
                   options.add_argument(argument)
@@ -92,6 +99,11 @@ module DVLA
 
               ::Capybara::Selenium::Driver.new(app, **driver_options).tap do |driver|
                 driver.browser.execute_cdp('Emulation.setScriptExecutionDisabled', value: true) if no_js && browser == :edge
+                if kwargs[:window_size] && browser == :firefox
+                  size = parse_window_size(kwargs[:window_size])
+                  driver.browser.manage.window.resize_to(size[0], size[1])
+                end
+
               end
             end
           else
@@ -101,6 +113,7 @@ module DVLA
 
             browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
             browser_options = browser_options.merge(kwargs[:browser_options]) if kwargs[:browser_options]
+            browser_options[:'window-size'] = kwargs[:window_size] if kwargs[:window_size]
             browser_options[:'blink-settings'] = 'scriptEnabled=false' if no_js
 
             if kwargs[:proxy]
@@ -116,7 +129,12 @@ module DVLA
                 browser_options:,
                 save_path: kwargs[:save_path],
                 url: kwargs[:remote],
-                )
+                ).tap do |driver|
+                if kwargs[:window_size]
+                  size = parse_window_size(kwargs[:window_size])
+                  driver.browser.resize(width: size[0], height: size[1])
+                end
+              end
             end
           end
 
@@ -133,6 +151,11 @@ module DVLA
       def self.respond_to_missing?(method, *args)
         method.match(DRIVER_REGEX) || super
       end
+
+      def self.parse_window_size(window_size)
+        window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)
+      end
+      private_class_method :parse_window_size
     end
   end
 end

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,10 +1,12 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition)(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition)(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
+      DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition|playwright_(?<pw_browser>chromium|firefox|webkit))(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition|playwright_(?<pw_browser_no_headless>chromium|firefox|webkit))(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
+      PLAYWRIGHT_ACCEPTED_PARAMS = %i[headless browser_type proxy window_size].freeze
+      PLAYWRIGHT_DRIVERS = %i[playwright_chromium playwright_firefox playwright_webkit].freeze
       SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size mobile_emulation].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
@@ -77,6 +79,7 @@ module DVLA
                 if kwargs[:mobile_emulation] && %i[chrome edge].include?(browser)
                   puts 'Warning: window_size will be overridden by mobile_emulation' if kwargs[:window_size]
                   emulation = resolve_mobile_emulation(kwargs[:mobile_emulation])
+                  puts "Mobile emulation: #{kwargs[:mobile_emulation]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
                   options.add_emulation(**emulation)
                 end
 
@@ -110,6 +113,24 @@ module DVLA
                   driver.browser.manage.window.resize_to(size[0], size[1])
                 end
               end
+            end
+          when *PLAYWRIGHT_DRIVERS
+            pw_browser = (matches[:pw_browser] || matches[:pw_browser_no_headless]).to_sym
+
+            kwargs.each do |key, _value|
+              puts "Key: '#{key}' will be ignored | Use one from: '#{PLAYWRIGHT_ACCEPTED_PARAMS}'" unless PLAYWRIGHT_ACCEPTED_PARAMS.include?(key)
+            end
+
+            warn_if_playwright_browser_missing(pw_browser)
+
+            ::Capybara.register_driver method do |app|
+              playwright_options = { browser_type: pw_browser, headless: headless }
+              playwright_options[:proxy] = { server: kwargs[:proxy] } if kwargs[:proxy]
+              if kwargs[:window_size]
+                size = parse_window_size(kwargs[:window_size])
+                playwright_options[:screen] = { width: size[0], height: size[1] }
+              end
+              Capybara::Playwright::Driver.new(app, **playwright_options)
             end
           else
             kwargs.each do |key, _value|
@@ -156,6 +177,15 @@ module DVLA
         method.match(DRIVER_REGEX) || super
       end
 
+      def self.warn_if_playwright_browser_missing(browser_type)
+        cache_root = RUBY_PLATFORM.include?('darwin') ? '~/Library/Caches/ms-playwright' : '~/.cache/ms-playwright'
+        cache_root = File.expand_path(cache_root)
+        return if Dir.glob("#{cache_root}/#{browser_type}-*/").any? { |dir| Dir.exist?(dir) && !Dir.empty?(dir) }
+
+        puts "Warning: No Playwright '#{browser_type}' browser found in #{cache_root}. Run: npx playwright@<version> install #{browser_type}"
+      end
+      private_class_method :warn_if_playwright_browser_missing
+
       def self.parse_window_size(window_size)
         size = window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)
         raise ArgumentError, "window_size must have exactly 2 elements [width, height], got: #{window_size.inspect}" unless size.length == 2
@@ -166,10 +196,13 @@ module DVLA
 
       def self.resolve_mobile_emulation(mobile_emulation)
         if mobile_emulation.is_a?(Symbol)
-          device_name = MOBILE_PROFILES[mobile_emulation]
-          raise ArgumentError, "Unknown mobile profile: ':#{mobile_emulation}'. Available: #{MOBILE_PROFILES.keys.map { |k| ":#{k}" }.join(', ')}" unless device_name
+          profile = MOBILE_PROFILES[mobile_emulation]
+          raise ArgumentError, "Unknown mobile profile: ':#{mobile_emulation}'. Available: #{MOBILE_PROFILES.keys.map { |k| ":#{k}" }.join(', ')}" unless profile
 
-          { device_name: }
+          {
+            device_metrics: { width: profile[:width], height: profile[:height], pixelRatio: profile[:device_scale_factor], touch: profile[:has_touch] },
+            user_agent: profile[:user_agent]
+          }
         else
           mobile_emulation.transform_keys(&:to_sym)
         end

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,12 +1,10 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?<headless>headless_)?(?<driver>selenium_(?<browser>chrome|firefox|edge|safari)|cuprite|apparition|playwright_(?<pw_browser>chromium|firefox|webkit))(?<no_js>_no_js)?(?<proxied>_proxied)?$/
+      DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition)(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition)(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
-      PLAYWRIGHT_ACCEPTED_PARAMS = %i[headless browser_type proxy window_size].freeze
-      PLAYWRIGHT_DRIVERS = %i[playwright_chromium playwright_firefox playwright_webkit].freeze
       SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size emulate_device].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
@@ -22,16 +20,17 @@ module DVLA
         matches = method.match(DRIVER_REGEX)
         return super unless matches
 
-        headless = !matches[:headless].nil?
-        no_js    = !matches[:no_js].nil?
-        driver   = matches[:driver].to_sym
+        headless = matches[:headless].is_a?(String)
+        no_js    = matches[:no_js].is_a?(String) || matches[:no_js_no_headless].is_a?(String)
+        proxied  = matches[:proxied].is_a?(String) || matches[:proxied_no_headless].is_a?(String)
+        driver   = matches[:driver]&.to_sym || matches[:driver_no_headless]&.to_sym
+        browser  = matches[:browser] || matches[:browser_no_headless]
 
-        raise ArgumentError, "Method '#{method}' requires proxy parameter" if matches[:proxied] && !kwargs[:proxy]
+        raise ArgumentError, "Method '#{method}' requires proxy parameter" if proxied && !kwargs[:proxy]
 
         case driver
-        when *SELENIUM_DRIVERS   then register_selenium_driver(method, matches[:browser].to_sym, headless:, no_js:, **kwargs)
-        when *PLAYWRIGHT_DRIVERS then register_playwright_driver(method, matches[:pw_browser].to_sym, headless:, **kwargs)
-        else                          register_other_driver(method, driver, headless:, no_js:, **kwargs)
+        when *SELENIUM_DRIVERS then register_selenium_driver(method, browser.to_sym, headless:, no_js:, **kwargs)
+        else                        register_other_driver(method, driver, headless:, no_js:, **kwargs)
         end
 
         puts "Driver set to: '#{method}'"
@@ -47,6 +46,7 @@ module DVLA
       def self.register_selenium_driver(method, browser, headless:, no_js:, **kwargs)
         warn_ignored_kwargs(kwargs, SELENIUM_ACCEPTED_PARAMS)
         puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && browser == :safari
+        puts 'Warning: window_size will be overridden by emulate_device' if kwargs[:window_size] && kwargs[:emulate_device]
 
         ::Capybara.register_driver method do |app|
           options        = build_selenium_options(browser, headless:, no_js:, **kwargs)
@@ -64,22 +64,6 @@ module DVLA
         end
       end
       private_class_method :register_selenium_driver
-
-      def self.register_playwright_driver(method, pw_browser, headless:, **kwargs)
-        warn_ignored_kwargs(kwargs, PLAYWRIGHT_ACCEPTED_PARAMS)
-        warn_if_playwright_browser_missing(pw_browser)
-
-        ::Capybara.register_driver method do |app|
-          opts = { browser_type: pw_browser, headless: }
-          opts[:proxy] = { server: kwargs[:proxy] } if kwargs[:proxy]
-          if kwargs[:window_size]
-            size = parse_window_size(kwargs[:window_size])
-            opts[:screen] = { width: size[0], height: size[1] }
-          end
-          Capybara::Playwright::Driver.new(app, **opts)
-        end
-      end
-      private_class_method :register_playwright_driver
 
       def self.register_other_driver(method, driver, headless:, no_js:, **kwargs)
         warn_ignored_kwargs(kwargs, OTHER_ACCEPTED_PARAMS)
@@ -99,15 +83,6 @@ module DVLA
         end
       end
       private_class_method :register_other_driver
-
-      def self.warn_if_playwright_browser_missing(browser_type)
-        cache_root = RUBY_PLATFORM.include?('darwin') ? '~/Library/Caches/ms-playwright' : '~/.cache/ms-playwright'
-        cache_root = File.expand_path(cache_root)
-        return if Dir.glob("#{cache_root}/#{browser_type}-*/").any? { |dir| Dir.exist?(dir) && !Dir.empty?(dir) }
-
-        puts "Warning: No Playwright '#{browser_type}' browser found in #{cache_root}. Run: npx playwright@<version> install #{browser_type}"
-      end
-      private_class_method :warn_if_playwright_browser_missing
 
       def self.build_selenium_options(browser, headless:, no_js:, **kwargs)
         return Selenium::WebDriver::Safari::Options.new if browser == :safari
@@ -129,9 +104,8 @@ module DVLA
         end
 
         if kwargs[:emulate_device] && %i[chrome edge].include?(browser)
-          puts 'Warning: window_size will be overridden by emulate_device' if kwargs[:window_size]
           emulation = resolve_emulate_device(kwargs[:emulate_device])
-          puts "Mobile emulation: #{kwargs[:emulate_device]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
+          puts "Mobile emulation: #{kwargs[:emulate_device]} | #{emulation[:device_metrics]&.map { |k, v| "#{k}: #{v}" }&.join(', ')}" if emulation[:device_metrics]
           options.add_emulation(**emulation)
         end
 

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -7,7 +7,7 @@ module DVLA
       OTHER_DRIVERS = %i[cuprite apparition].freeze
       PLAYWRIGHT_ACCEPTED_PARAMS = %i[headless browser_type proxy window_size].freeze
       PLAYWRIGHT_DRIVERS = %i[playwright_chromium playwright_firefox playwright_webkit].freeze
-      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size mobile_emulation].freeze
+      SELENIUM_ACCEPTED_PARAMS = %i[remote additional_arguments additional_preferences binary proxy window_size emulate_device].freeze
       SELENIUM_DRIVERS = %i[selenium_chrome selenium_firefox selenium_edge selenium_safari].freeze
 
       # Creates methods in the Drivers module that matches the DRIVER_REGEX
@@ -128,10 +128,10 @@ module DVLA
           options.add_argument("--window-size=#{size[0]},#{size[1]}")
         end
 
-        if kwargs[:mobile_emulation] && %i[chrome edge].include?(browser)
-          puts 'Warning: window_size will be overridden by mobile_emulation' if kwargs[:window_size]
-          emulation = resolve_mobile_emulation(kwargs[:mobile_emulation])
-          puts "Mobile emulation: #{kwargs[:mobile_emulation]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
+        if kwargs[:emulate_device] && %i[chrome edge].include?(browser)
+          puts 'Warning: window_size will be overridden by emulate_device' if kwargs[:window_size]
+          emulation = resolve_emulate_device(kwargs[:emulate_device])
+          puts "Mobile emulation: #{kwargs[:emulate_device]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
           options.add_emulation(**emulation)
         end
 
@@ -187,20 +187,20 @@ module DVLA
       end
       private_class_method :parse_window_size
 
-      def self.resolve_mobile_emulation(mobile_emulation)
-        if mobile_emulation.is_a?(Symbol)
-          profile = MOBILE_PROFILES[mobile_emulation]
-          raise ArgumentError, "Unknown mobile profile: ':#{mobile_emulation}'. Available: #{MOBILE_PROFILES.keys.map { |k| ":#{k}" }.join(', ')}" unless profile
+      def self.resolve_emulate_device(emulate_device)
+        if emulate_device.is_a?(Symbol)
+          profile = MOBILE_PROFILES[emulate_device]
+          raise ArgumentError, "Unknown mobile profile: ':#{emulate_device}'. Available: #{MOBILE_PROFILES.keys.map { |k| ":#{k}" }.join(', ')}" unless profile
 
           {
             device_metrics: { width: profile[:width], height: profile[:height], pixelRatio: profile[:device_scale_factor], touch: profile[:has_touch] },
             user_agent: profile[:user_agent]
           }
         else
-          mobile_emulation.transform_keys(&:to_sym)
+          emulate_device.transform_keys(&:to_sym)
         end
       end
-      private_class_method :resolve_mobile_emulation
+      private_class_method :resolve_emulate_device
     end
   end
 end

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -1,7 +1,7 @@
 module DVLA
   module Browser
     module Drivers
-      DRIVER_REGEX = /^(?:(?<headless>headless_)(?<driver>selenium_(?<browser>chrome|firefox|edge)|cuprite|apparition|playwright_(?<pw_browser>chromium|firefox|webkit))(?<no_js>_no_js)?(?<proxied>_proxied)?|(?<driver_no_headless>selenium_(?<browser_no_headless>chrome|firefox|edge|safari)|cuprite|apparition|playwright_(?<pw_browser_no_headless>chromium|firefox|webkit))(?<no_js_no_headless>_no_js)?(?<proxied_no_headless>_proxied)?)$/
+      DRIVER_REGEX = /^(?<headless>headless_)?(?<driver>selenium_(?<browser>chrome|firefox|edge|safari)|cuprite|apparition|playwright_(?<pw_browser>chromium|firefox|webkit))(?<no_js>_no_js)?(?<proxied>_proxied)?$/
 
       OTHER_ACCEPTED_PARAMS = %i[timeout browser_options save_path remote proxy window_size].freeze
       OTHER_DRIVERS = %i[cuprite apparition].freeze
@@ -20,11 +20,11 @@ module DVLA
       #   DVLA::Browser::Drivers.chrome(remote: 'http://localhost:4444/wd/hub')
       def self.method_missing(method, *args, **kwargs, &)
         if (matches = method.match(DRIVER_REGEX))
-          headless = matches[:headless].is_a? String
-          no_js = matches[:no_js].is_a?(String) || matches[:no_js_no_headless].is_a?(String)
-          proxied = matches[:proxied].is_a?(String) || matches[:proxied_no_headless].is_a?(String)
-          driver = matches[:driver]&.to_sym || matches[:driver_no_headless]&.to_sym
-          browser_match = matches[:browser] || matches[:browser_no_headless]
+          headless = !matches[:headless].nil?
+          no_js = !matches[:no_js].nil?
+          proxied = !matches[:proxied].nil?
+          driver = matches[:driver].to_sym
+          browser_match = matches[:browser]
 
           if proxied && !kwargs[:proxy]
             raise ArgumentError, "Method '#{method}' requires proxy parameter"
@@ -34,73 +34,12 @@ module DVLA
           when *SELENIUM_DRIVERS
             browser = browser_match.to_sym
 
-            kwargs.each do |key, _value|
-              puts "Key: '#{key}' will be ignored | Use one from: '#{SELENIUM_ACCEPTED_PARAMS}'" unless SELENIUM_ACCEPTED_PARAMS.include?(key)
-            end
+            warn_ignored_kwargs(kwargs, SELENIUM_ACCEPTED_PARAMS)
 
             puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari].include?(browser)
 
             ::Capybara.register_driver method do |app|
-              if browser == :safari
-                options = Selenium::WebDriver::Safari::Options.new
-              else
-                options = Object.const_get("Selenium::WebDriver::#{browser.to_s.capitalize}::Options").new(web_socket_url: true)
-                options.binary = kwargs[:binary] if kwargs[:binary]
-                options.add_argument('--disable-dev-shm-usage')
-
-                if headless
-                  options.add_argument('--headless')
-                  options.add_argument('--no-sandbox')
-                end
-
-                if kwargs[:proxy]
-                  if browser == :firefox
-                    proxy_uri = URI.parse(kwargs[:proxy])
-                    proxy_host = proxy_uri.host == '0.0.0.0' ? '127.0.0.1' : proxy_uri.host
-                    options.add_preference('network.proxy.type', 1)
-                    options.add_preference('network.proxy.http', proxy_host)
-                    options.add_preference('network.proxy.http_port', proxy_uri.port)
-                    options.add_preference('network.proxy.ssl', proxy_host)
-                    options.add_preference('network.proxy.ssl_port', proxy_uri.port)
-                    options.add_preference('network.proxy.no_proxies_on', '')
-                    options.add_preference('security.cert_pinning.enforcement_level', 0)
-                    options.add_preference('security.enterprise_roots.enabled', true)
-                  else
-                    options.add_argument("--proxy-server=#{kwargs[:proxy]}")
-                    options.add_argument('--ignore-certificate-errors')
-                  end
-                end
-
-                if kwargs[:window_size] && %i[chrome edge].include?(browser)
-                  size = parse_window_size(kwargs[:window_size])
-                  options.add_argument("--window-size=#{size[0]},#{size[1]}")
-                end
-
-                if kwargs[:mobile_emulation] && %i[chrome edge].include?(browser)
-                  puts 'Warning: window_size will be overridden by mobile_emulation' if kwargs[:window_size]
-                  emulation = resolve_mobile_emulation(kwargs[:mobile_emulation])
-                  puts "Mobile emulation: #{kwargs[:mobile_emulation]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
-                  options.add_emulation(**emulation)
-                end
-
-                kwargs[:additional_arguments] && kwargs[:additional_arguments].each do |argument|
-                  argument.prepend('--') unless argument.start_with?('--')
-                  options.add_argument(argument)
-                end
-
-                kwargs[:additional_preferences] && kwargs[:additional_preferences].each do |preference|
-                  key, value = preference.first
-                  options.add_preference(key, value)
-                end
-
-                if no_js
-                  if browser == :chrome
-                    options.add_preference('profile.managed_default_content_settings.javascript', 2)
-                  elsif browser == :firefox
-                    options.add_preference('javascript.enabled', false)
-                  end
-                end
-              end
+              options = build_selenium_options(browser, headless: headless, no_js: no_js, **kwargs)
 
               driver_browser = kwargs[:remote] ? :remote : browser
               driver_options = { browser: driver_browser, options: }
@@ -115,11 +54,9 @@ module DVLA
               end
             end
           when *PLAYWRIGHT_DRIVERS
-            pw_browser = (matches[:pw_browser] || matches[:pw_browser_no_headless]).to_sym
+            pw_browser = matches[:pw_browser].to_sym
 
-            kwargs.each do |key, _value|
-              puts "Key: '#{key}' will be ignored | Use one from: '#{PLAYWRIGHT_ACCEPTED_PARAMS}'" unless PLAYWRIGHT_ACCEPTED_PARAMS.include?(key)
-            end
+            warn_ignored_kwargs(kwargs, PLAYWRIGHT_ACCEPTED_PARAMS)
 
             warn_if_playwright_browser_missing(pw_browser)
 
@@ -133,9 +70,7 @@ module DVLA
               Capybara::Playwright::Driver.new(app, **playwright_options)
             end
           else
-            kwargs.each do |key, _value|
-              puts "Key: '#{key}' will be ignored | Use one from: '#{OTHER_ACCEPTED_PARAMS}'" unless OTHER_ACCEPTED_PARAMS.include?(key)
-            end
+            warn_ignored_kwargs(kwargs, OTHER_ACCEPTED_PARAMS)
 
             browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
             browser_options = browser_options.merge(kwargs[:browser_options]) if kwargs[:browser_options]
@@ -147,19 +82,15 @@ module DVLA
             end
 
             ::Capybara.register_driver method do |app|
-              Object.const_get("Capybara::#{driver.to_s.capitalize}::Driver").new(
-                app,
+              driver_opts = {
                 headless:,
                 timeout: kwargs[:timeout] || 60,
                 browser_options:,
                 save_path: kwargs[:save_path],
                 url: kwargs[:remote],
-                ).tap do |driver|
-                if kwargs[:window_size]
-                  size = parse_window_size(kwargs[:window_size])
-                  driver.browser.resize(width: size[0], height: size[1])
-                end
-              end
+              }
+              driver_opts[:screen_size] = parse_window_size(kwargs[:window_size]) if kwargs[:window_size]
+              Object.const_get("Capybara::#{driver.to_s.capitalize}::Driver").new(app, **driver_opts)
             end
           end
 
@@ -185,6 +116,76 @@ module DVLA
         puts "Warning: No Playwright '#{browser_type}' browser found in #{cache_root}. Run: npx playwright@<version> install #{browser_type}"
       end
       private_class_method :warn_if_playwright_browser_missing
+
+      def self.build_selenium_options(browser, headless:, no_js:, **kwargs)
+        return Selenium::WebDriver::Safari::Options.new if browser == :safari
+
+        options = Object.const_get("Selenium::WebDriver::#{browser.to_s.capitalize}::Options").new(web_socket_url: true)
+        options.binary = kwargs[:binary] if kwargs[:binary]
+        options.add_argument('--disable-dev-shm-usage')
+
+        if headless
+          options.add_argument('--headless')
+          options.add_argument('--no-sandbox')
+        end
+
+        apply_selenium_proxy(options, browser, kwargs[:proxy]) if kwargs[:proxy]
+
+        if kwargs[:window_size] && %i[chrome edge].include?(browser)
+          size = parse_window_size(kwargs[:window_size])
+          options.add_argument("--window-size=#{size[0]},#{size[1]}")
+        end
+
+        if kwargs[:mobile_emulation] && %i[chrome edge].include?(browser)
+          puts 'Warning: window_size will be overridden by mobile_emulation' if kwargs[:window_size]
+          emulation = resolve_mobile_emulation(kwargs[:mobile_emulation])
+          puts "Mobile emulation: #{kwargs[:mobile_emulation]} | #{emulation[:device_metrics].map { |k, v| "#{k}: #{v}" }.join(', ')}"
+          options.add_emulation(**emulation)
+        end
+
+        kwargs[:additional_arguments]&.each do |argument|
+          argument.prepend('--') unless argument.start_with?('--')
+          options.add_argument(argument)
+        end
+
+        kwargs[:additional_preferences]&.each do |preference|
+          options.add_preference(*preference.first)
+        end
+
+        if no_js
+          options.add_preference('profile.managed_default_content_settings.javascript', 2) if browser == :chrome
+          options.add_preference('javascript.enabled', false) if browser == :firefox
+        end
+
+        options
+      end
+      private_class_method :build_selenium_options
+
+      def self.apply_selenium_proxy(options, browser, proxy)
+        if browser == :firefox
+          proxy_uri = URI.parse(proxy)
+          proxy_host = proxy_uri.host == '0.0.0.0' ? '127.0.0.1' : proxy_uri.host
+          options.add_preference('network.proxy.type', 1)
+          options.add_preference('network.proxy.http', proxy_host)
+          options.add_preference('network.proxy.http_port', proxy_uri.port)
+          options.add_preference('network.proxy.ssl', proxy_host)
+          options.add_preference('network.proxy.ssl_port', proxy_uri.port)
+          options.add_preference('network.proxy.no_proxies_on', '')
+          options.add_preference('security.cert_pinning.enforcement_level', 0)
+          options.add_preference('security.enterprise_roots.enabled', true)
+        else
+          options.add_argument("--proxy-server=#{proxy}")
+          options.add_argument('--ignore-certificate-errors')
+        end
+      end
+      private_class_method :apply_selenium_proxy
+
+      def self.warn_ignored_kwargs(kwargs, accepted)
+        kwargs.each_key do |key|
+          puts "Key: '#{key}' will be ignored | Use one from: '#{accepted}'" unless accepted.include?(key)
+        end
+      end
+      private_class_method :warn_ignored_kwargs
 
       def self.parse_window_size(window_size)
         size = window_size.is_a?(Array) ? window_size : window_size.to_s.split(/[x,]/).map(&:to_i)

--- a/lib/dvla/browser/drivers/meta_drivers.rb
+++ b/lib/dvla/browser/drivers/meta_drivers.rb
@@ -19,94 +19,86 @@ module DVLA
       # @example Driver with additional arguments
       #   DVLA::Browser::Drivers.chrome(remote: 'http://localhost:4444/wd/hub')
       def self.method_missing(method, *args, **kwargs, &)
-        if (matches = method.match(DRIVER_REGEX))
-          headless = !matches[:headless].nil?
-          no_js = !matches[:no_js].nil?
-          proxied = !matches[:proxied].nil?
-          driver = matches[:driver].to_sym
-          browser_match = matches[:browser]
+        matches = method.match(DRIVER_REGEX)
+        return super unless matches
 
-          if proxied && !kwargs[:proxy]
-            raise ArgumentError, "Method '#{method}' requires proxy parameter"
-          end
+        headless = !matches[:headless].nil?
+        no_js    = !matches[:no_js].nil?
+        driver   = matches[:driver].to_sym
 
-          case driver
-          when *SELENIUM_DRIVERS
-            browser = browser_match.to_sym
+        raise ArgumentError, "Method '#{method}' requires proxy parameter" if matches[:proxied] && !kwargs[:proxy]
 
-            warn_ignored_kwargs(kwargs, SELENIUM_ACCEPTED_PARAMS)
-
-            puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && %i[safari].include?(browser)
-
-            ::Capybara.register_driver method do |app|
-              options = build_selenium_options(browser, headless: headless, no_js: no_js, **kwargs)
-
-              driver_browser = kwargs[:remote] ? :remote : browser
-              driver_options = { browser: driver_browser, options: }
-              driver_options[:url] = kwargs[:remote] if kwargs[:remote]
-
-              ::Capybara::Selenium::Driver.new(app, **driver_options).tap do |driver|
-                driver.browser.execute_cdp('Emulation.setScriptExecutionDisabled', value: true) if no_js && browser == :edge
-                if kwargs[:window_size] && browser == :firefox
-                  size = parse_window_size(kwargs[:window_size])
-                  driver.browser.manage.window.resize_to(size[0], size[1])
-                end
-              end
-            end
-          when *PLAYWRIGHT_DRIVERS
-            pw_browser = matches[:pw_browser].to_sym
-
-            warn_ignored_kwargs(kwargs, PLAYWRIGHT_ACCEPTED_PARAMS)
-
-            warn_if_playwright_browser_missing(pw_browser)
-
-            ::Capybara.register_driver method do |app|
-              playwright_options = { browser_type: pw_browser, headless: headless }
-              playwright_options[:proxy] = { server: kwargs[:proxy] } if kwargs[:proxy]
-              if kwargs[:window_size]
-                size = parse_window_size(kwargs[:window_size])
-                playwright_options[:screen] = { width: size[0], height: size[1] }
-              end
-              Capybara::Playwright::Driver.new(app, **playwright_options)
-            end
-          else
-            warn_ignored_kwargs(kwargs, OTHER_ACCEPTED_PARAMS)
-
-            browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
-            browser_options = browser_options.merge(kwargs[:browser_options]) if kwargs[:browser_options]
-            browser_options[:'blink-settings'] = 'scriptEnabled=false' if no_js
-
-            if kwargs[:proxy]
-              browser_options[:'proxy-server'] = kwargs[:proxy]
-              browser_options[:'ignore-certificate-errors'] = nil
-            end
-
-            ::Capybara.register_driver method do |app|
-              driver_opts = {
-                headless:,
-                timeout: kwargs[:timeout] || 60,
-                browser_options:,
-                save_path: kwargs[:save_path],
-                url: kwargs[:remote],
-              }
-              driver_opts[:screen_size] = parse_window_size(kwargs[:window_size]) if kwargs[:window_size]
-              Object.const_get("Capybara::#{driver.to_s.capitalize}::Driver").new(app, **driver_opts)
-            end
-          end
-
-          puts "Driver set to: '#{method}'"
-
-          ::Capybara.javascript_driver = method
-          ::Capybara.default_driver = method
-          ::Capybara.current_driver = method
-        else
-          super.method_missing(method, *args, &)
+        case driver
+        when *SELENIUM_DRIVERS   then register_selenium_driver(method, matches[:browser].to_sym, headless:, no_js:, **kwargs)
+        when *PLAYWRIGHT_DRIVERS then register_playwright_driver(method, matches[:pw_browser].to_sym, headless:, **kwargs)
+        else                          register_other_driver(method, driver, headless:, no_js:, **kwargs)
         end
+
+        puts "Driver set to: '#{method}'"
+        ::Capybara.javascript_driver = method
+        ::Capybara.default_driver    = method
+        ::Capybara.current_driver    = method
       end
 
       def self.respond_to_missing?(method, *args)
         method.match(DRIVER_REGEX) || super
       end
+
+      def self.register_selenium_driver(method, browser, headless:, no_js:, **kwargs)
+        warn_ignored_kwargs(kwargs, SELENIUM_ACCEPTED_PARAMS)
+        puts "Warning: window_size is not supported for #{browser}" if kwargs[:window_size] && browser == :safari
+
+        ::Capybara.register_driver method do |app|
+          options        = build_selenium_options(browser, headless:, no_js:, **kwargs)
+          driver_browser = kwargs[:remote] ? :remote : browser
+          driver_options = { browser: driver_browser, options: }
+          driver_options[:url] = kwargs[:remote] if kwargs[:remote]
+
+          ::Capybara::Selenium::Driver.new(app, **driver_options).tap do |d|
+            d.browser.execute_cdp('Emulation.setScriptExecutionDisabled', value: true) if no_js && browser == :edge
+            if kwargs[:window_size] && browser == :firefox
+              size = parse_window_size(kwargs[:window_size])
+              d.browser.manage.window.resize_to(size[0], size[1])
+            end
+          end
+        end
+      end
+      private_class_method :register_selenium_driver
+
+      def self.register_playwright_driver(method, pw_browser, headless:, **kwargs)
+        warn_ignored_kwargs(kwargs, PLAYWRIGHT_ACCEPTED_PARAMS)
+        warn_if_playwright_browser_missing(pw_browser)
+
+        ::Capybara.register_driver method do |app|
+          opts = { browser_type: pw_browser, headless: }
+          opts[:proxy] = { server: kwargs[:proxy] } if kwargs[:proxy]
+          if kwargs[:window_size]
+            size = parse_window_size(kwargs[:window_size])
+            opts[:screen] = { width: size[0], height: size[1] }
+          end
+          Capybara::Playwright::Driver.new(app, **opts)
+        end
+      end
+      private_class_method :register_playwright_driver
+
+      def self.register_other_driver(method, driver, headless:, no_js:, **kwargs)
+        warn_ignored_kwargs(kwargs, OTHER_ACCEPTED_PARAMS)
+
+        browser_options = { 'no-sandbox': nil, 'disable-smooth-scrolling': true }
+        browser_options.merge!(kwargs[:browser_options]) if kwargs[:browser_options]
+        browser_options[:'blink-settings'] = 'scriptEnabled=false' if no_js
+        if kwargs[:proxy]
+          browser_options[:'proxy-server'] = kwargs[:proxy]
+          browser_options[:'ignore-certificate-errors'] = nil
+        end
+
+        ::Capybara.register_driver method do |app|
+          opts = { headless:, timeout: kwargs[:timeout] || 60, browser_options:, save_path: kwargs[:save_path], url: kwargs[:remote] }
+          opts[:screen_size] = parse_window_size(kwargs[:window_size]) if kwargs[:window_size]
+          Object.const_get("Capybara::#{driver.to_s.capitalize}::Driver").new(app, **opts)
+        end
+      end
+      private_class_method :register_other_driver
 
       def self.warn_if_playwright_browser_missing(browser_type)
         cache_root = RUBY_PLATFORM.include?('darwin') ? '~/Library/Caches/ms-playwright' : '~/.cache/ms-playwright'

--- a/lib/dvla/browser/drivers/mobile_profiles.rb
+++ b/lib/dvla/browser/drivers/mobile_profiles.rb
@@ -1,0 +1,533 @@
+module DVLA
+  module Browser
+    module Drivers
+      # Borrowed from https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/common/Device.ts
+      MOBILE_PROFILES = {
+        blackberry_playbook: {
+          user_agent: 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
+          width: 600, height: 1024, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        blackberry_playbook_landscape: {
+          user_agent: 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
+          width: 1024, height: 600, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        blackberry_z30: {
+          user_agent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
+          width: 360, height: 640, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        blackberry_z30_landscape: {
+          user_agent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
+          width: 640, height: 360, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        galaxy_note_3: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 360, height: 640, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_note_3_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 640, height: 360, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_note_ii: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 360, height: 640, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        galaxy_note_ii_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 640, height: 360, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        galaxy_s_iii: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 360, height: 640, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        galaxy_s_iii_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+          width: 640, height: 360, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        galaxy_s5: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 360, height: 640, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_s5_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 640, height: 360, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_s8: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.0; SM-G950U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36',
+          width: 360, height: 740, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_s8_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.0; SM-G950U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36',
+          width: 740, height: 360, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        galaxy_s9_plus: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G965U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36',
+          width: 320, height: 658, device_scale_factor: 4.5, mobile: true, has_touch: true
+        },
+        galaxy_s9_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G965U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36',
+          width: 658, height: 320, device_scale_factor: 4.5, mobile: true, has_touch: true
+        },
+        galaxy_tab_s4: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.1.0; SM-T837A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.0 Safari/537.36',
+          width: 712, height: 1138, device_scale_factor: 2.25, mobile: true, has_touch: true
+        },
+        galaxy_tab_s4_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.1.0; SM-T837A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.0 Safari/537.36',
+          width: 1138, height: 712, device_scale_factor: 2.25, mobile: true, has_touch: true
+        },
+        ipad: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 768, height: 1024, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 1024, height: 768, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_gen_6: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 768, height: 1024, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_gen_6_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 1024, height: 768, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_gen_7: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
+          width: 810, height: 1080, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_gen_7_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
+          width: 1080, height: 810, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_mini: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 768, height: 1024, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_mini_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 1024, height: 768, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_pro: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 1024, height: 1366, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+          width: 1366, height: 1024, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_pro_11: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 834, height: 1194, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        ipad_pro_11_landscape: {
+          user_agent: 'Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 1194, height: 834, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_4: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53',
+          width: 320, height: 480, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_4_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53',
+          width: 480, height: 320, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_5: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+          width: 320, height: 568, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_5_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+          width: 568, height: 320, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_6: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 375, height: 667, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_6_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 667, height: 375, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_6_plus: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 414, height: 736, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_6_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 736, height: 414, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_7: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 375, height: 667, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_7_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 667, height: 375, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_7_plus: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 414, height: 736, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_7_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 736, height: 414, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_8: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 375, height: 667, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_8_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 667, height: 375, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_8_plus: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 414, height: 736, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_8_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 736, height: 414, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_se: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+          width: 320, height: 568, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_se_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+          width: 568, height: 320, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_x: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 375, height: 812, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_x_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+          width: 812, height: 375, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_xr: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 414, height: 896, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_xr_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+          width: 896, height: 414, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_11: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 414, height: 828, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_11_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 828, height: 414, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        iphone_11_pro: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 375, height: 812, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_11_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 812, height: 375, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_11_pro_max: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 414, height: 896, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_11_pro_max_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1',
+          width: 896, height: 414, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 390, height: 844, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 844, height: 390, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_pro: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 390, height: 844, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 844, height: 390, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_pro_max: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 428, height: 926, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_pro_max_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 926, height: 428, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_mini: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 375, height: 812, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_12_mini_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 812, height: 375, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 390, height: 844, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 844, height: 390, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_pro: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 390, height: 844, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 844, height: 390, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_pro_max: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 428, height: 926, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_pro_max_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 926, height: 428, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_mini: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 375, height: 812, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_13_mini_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+          width: 812, height: 375, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 390, height: 663, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 750, height: 340, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_plus: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 428, height: 745, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 832, height: 378, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_pro: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 393, height: 659, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 734, height: 343, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_pro_max: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 430, height: 739, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_14_pro_max_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+          width: 814, height: 380, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 393, height: 659, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 734, height: 343, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_plus: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 430, height: 739, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_plus_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 814, height: 380, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_pro: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 393, height: 659, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_pro_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 734, height: 343, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_pro_max: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 430, height: 739, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        iphone_15_pro_max_landscape: {
+          user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+          width: 814, height: 380, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        jiophone_2: {
+          user_agent: 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
+          width: 240, height: 320, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        jiophone_2_landscape: {
+          user_agent: 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
+          width: 320, height: 240, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        kindle_fire_hdx: {
+          user_agent: 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
+          width: 800, height: 1280, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        kindle_fire_hdx_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
+          width: 1280, height: 800, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        lg_optimus_l70: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 384, height: 640, device_scale_factor: 1.25, mobile: true, has_touch: true
+        },
+        lg_optimus_l70_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 640, height: 384, device_scale_factor: 1.25, mobile: true, has_touch: true
+        },
+        microsoft_lumia_550: {
+          user_agent: 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+          width: 640, height: 360, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        microsoft_lumia_950: {
+          user_agent: 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+          width: 360, height: 640, device_scale_factor: 4, mobile: true, has_touch: true
+        },
+        microsoft_lumia_950_landscape: {
+          user_agent: 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+          width: 640, height: 360, device_scale_factor: 4, mobile: true, has_touch: true
+        },
+        moto_g4: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 360, height: 640, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        moto_g4_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 640, height: 360, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        nexus_10: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
+          width: 800, height: 1280, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nexus_10_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
+          width: 1280, height: 800, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nexus_4: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 384, height: 640, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nexus_4_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 640, height: 384, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nexus_5: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 360, height: 640, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        nexus_5_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 640, height: 360, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        nexus_5x: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 412, height: 732, device_scale_factor: 2.625, mobile: true, has_touch: true
+        },
+        nexus_5x_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 732, height: 412, device_scale_factor: 2.625, mobile: true, has_touch: true
+        },
+        nexus_6: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 412, height: 732, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        nexus_6_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 732, height: 412, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        nexus_6p: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 412, height: 732, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        nexus_6p_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 732, height: 412, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        nexus_7: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
+          width: 600, height: 960, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nexus_7_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
+          width: 960, height: 600, device_scale_factor: 2, mobile: true, has_touch: true
+        },
+        nokia_lumia_520: {
+          user_agent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
+          width: 320, height: 533, device_scale_factor: 1.5, mobile: true, has_touch: true
+        },
+        nokia_lumia_520_landscape: {
+          user_agent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
+          width: 533, height: 320, device_scale_factor: 1.5, mobile: true, has_touch: true
+        },
+        nokia_n9: {
+          user_agent: 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
+          width: 480, height: 854, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        nokia_n9_landscape: {
+          user_agent: 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
+          width: 854, height: 480, device_scale_factor: 1, mobile: true, has_touch: true
+        },
+        pixel_2: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 411, height: 731, device_scale_factor: 2.625, mobile: true, has_touch: true
+        },
+        pixel_2_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 731, height: 411, device_scale_factor: 2.625, mobile: true, has_touch: true
+        },
+        pixel_2_xl: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 411, height: 823, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        pixel_2_xl_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+          width: 823, height: 411, device_scale_factor: 3.5, mobile: true, has_touch: true
+        },
+        pixel_3: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PQ1A.181105.017.A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36',
+          width: 393, height: 786, device_scale_factor: 2.75, mobile: true, has_touch: true
+        },
+        pixel_3_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PQ1A.181105.017.A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36',
+          width: 786, height: 393, device_scale_factor: 2.75, mobile: true, has_touch: true
+        },
+        pixel_4: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 10; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36',
+          width: 353, height: 745, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        pixel_4_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 10; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36',
+          width: 745, height: 353, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        pixel_4a_5g: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 11; Pixel 4a (5G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 353, height: 745, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        pixel_4a_5g_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 11; Pixel 4a (5G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 745, height: 353, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        pixel_5: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 393, height: 851, device_scale_factor: 3, mobile: true, has_touch: true
+        },
+        pixel_5_landscape: {
+          user_agent: 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4812.0 Mobile Safari/537.36',
+          width: 851, height: 393, device_scale_factor: 3, mobile: true, has_touch: true
+        }
+      }.freeze
+    end
+  end
+end

--- a/lib/dvla/browser/drivers/tasks.rb
+++ b/lib/dvla/browser/drivers/tasks.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+load File.expand_path('tasks/browser.rake', __dir__)

--- a/lib/dvla/browser/drivers/tasks/browser.rake
+++ b/lib/dvla/browser/drivers/tasks/browser.rake
@@ -7,12 +7,11 @@ DVLA_BROWSER_OPEN_TIME   = ENV.fetch('BROWSER_OPEN_TIME', 10).to_i
 DVLA_BROWSER_WINDOW_SIZE = ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800').then { |s| s.split('x').map(&:to_i) }.freeze
 DVLA_BROWSER_MOBILE_PROFILES = DVLA::Browser::Drivers::MOBILE_PROFILES.keys
 
-def dvla_browser_launch(driver_name, **)
-  DVLA::Browser::Drivers.send(driver_name, **)
+def dvla_browser_launch(driver_name, **opts)
+  DVLA::Browser::Drivers.send(driver_name, **opts)
   session = Capybara::Session.new(driver_name)
   session.visit(DVLA_BROWSER_URL)
   sleep DVLA_BROWSER_OPEN_TIME
-  # binding.irb
 ensure
   session.quit
 end
@@ -20,87 +19,195 @@ end
 namespace :browser do
   # ── Selenium Chrome ───────────────────────────────────────────────────────────
 
-  task(:selenium_chrome)                        { dvla_browser_launch(:selenium_chrome) }
-  task(:headless_selenium_chrome)               { dvla_browser_launch(:headless_selenium_chrome) }
-  task(:selenium_chrome_no_js)                  { dvla_browser_launch(:selenium_chrome_no_js) }
-  task(:headless_selenium_chrome_no_js)         { dvla_browser_launch(:headless_selenium_chrome_no_js) }
-  task(:selenium_chrome_proxied)                { dvla_browser_launch(:selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_chrome_proxied)       { dvla_browser_launch(:headless_selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_chrome_no_js_proxied) { dvla_browser_launch(:headless_selenium_chrome_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:selenium_chrome_emulated)               { dvla_browser_launch(:selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
-  task(:headless_selenium_chrome_emulated)      { dvla_browser_launch(:headless_selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
-  task(:selenium_chrome_window_size)            { dvla_browser_launch(:selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-  task(:headless_selenium_chrome_window_size)   { dvla_browser_launch(:headless_selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  desc 'Launch Chrome'
+  task(chrome: 'browser:chrome:default')
+
+  namespace :chrome do
+    desc 'Launch Chrome'
+    task(:default) { dvla_browser_launch(:selenium_chrome) }
+    desc 'Launch Chrome (headless)'
+    task(:headless) { dvla_browser_launch(:headless_selenium_chrome) }
+    desc 'Launch Chrome (no JS)'
+    task(:no_js) { dvla_browser_launch(:selenium_chrome_no_js) }
+    desc 'Launch Chrome (headless, no JS)'
+    task(:headless_no_js) { dvla_browser_launch(:headless_selenium_chrome_no_js) }
+    desc 'Launch Chrome (proxied)'
+    task(:proxied) { dvla_browser_launch(:selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Chrome (headless, proxied)'
+    task(:headless_proxied) { dvla_browser_launch(:headless_selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Chrome (headless, no JS, proxied)'
+    task(:headless_no_js_proxied) { dvla_browser_launch(:headless_selenium_chrome_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Chrome with mobile emulation'
+    task(:emulated) { dvla_browser_launch(:selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    desc 'Launch Chrome (headless) with mobile emulation'
+    task(:headless_emulated) { dvla_browser_launch(:headless_selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    desc "Launch Chrome at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:window_size) { dvla_browser_launch(:selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    desc "Launch Chrome (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:headless_window_size) { dvla_browser_launch(:headless_selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  end
 
   # ── Selenium Firefox ──────────────────────────────────────────────────────────
 
-  task(:selenium_firefox)                             { dvla_browser_launch(:selenium_firefox) }
-  task(:headless_selenium_firefox)                    { dvla_browser_launch(:headless_selenium_firefox) }
-  task(:selenium_firefox_no_js)                       { dvla_browser_launch(:selenium_firefox_no_js) }
-  task(:headless_selenium_firefox_no_js)              { dvla_browser_launch(:headless_selenium_firefox_no_js) }
-  task(:selenium_firefox_proxied)                     { dvla_browser_launch(:selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_firefox_proxied)            { dvla_browser_launch(:headless_selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_firefox_no_js_proxied)      { dvla_browser_launch(:headless_selenium_firefox_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:selenium_firefox_window_size)                 { dvla_browser_launch(:selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-  task(:headless_selenium_firefox_window_size)        { dvla_browser_launch(:headless_selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  desc 'Launch Firefox'
+  task(firefox: 'browser:firefox:default')
+
+  namespace :firefox do
+    desc 'Launch Firefox'
+    task(:default) { dvla_browser_launch(:selenium_firefox) }
+    desc 'Launch Firefox (headless)'
+    task(:headless) { dvla_browser_launch(:headless_selenium_firefox) }
+    desc 'Launch Firefox (no JS)'
+    task(:no_js) { dvla_browser_launch(:selenium_firefox_no_js) }
+    desc 'Launch Firefox (headless, no JS)'
+    task(:headless_no_js) { dvla_browser_launch(:headless_selenium_firefox_no_js) }
+    desc 'Launch Firefox (proxied)'
+    task(:proxied) { dvla_browser_launch(:selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Firefox (headless, proxied)'
+    task(:headless_proxied) { dvla_browser_launch(:headless_selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Firefox (headless, no JS, proxied)'
+    task(:headless_no_js_proxied) { dvla_browser_launch(:headless_selenium_firefox_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc "Launch Firefox at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:window_size) { dvla_browser_launch(:selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    desc "Launch Firefox (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:headless_window_size) { dvla_browser_launch(:headless_selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  end
 
   # ── Selenium Edge ─────────────────────────────────────────────────────────────
 
-  task(:selenium_edge)                          { dvla_browser_launch(:selenium_edge) }
-  task(:headless_selenium_edge)                 { dvla_browser_launch(:headless_selenium_edge) }
-  task(:selenium_edge_no_js)                    { dvla_browser_launch(:selenium_edge_no_js) }
-  task(:headless_selenium_edge_no_js)           { dvla_browser_launch(:headless_selenium_edge_no_js) }
-  task(:selenium_edge_proxied)                  { dvla_browser_launch(:selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_edge_proxied)         { dvla_browser_launch(:headless_selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_selenium_edge_no_js_proxied)   { dvla_browser_launch(:headless_selenium_edge_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:selenium_edge_emulated)                 { dvla_browser_launch(:selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
-  task(:headless_selenium_edge_emulated)        { dvla_browser_launch(:headless_selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
-  task(:selenium_edge_window_size)              { dvla_browser_launch(:selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-  task(:headless_selenium_edge_window_size)     { dvla_browser_launch(:headless_selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  desc 'Launch Edge'
+  task(edge: 'browser:edge:default')
+
+  namespace :edge do
+    desc 'Launch Edge'
+    task(:default) { dvla_browser_launch(:selenium_edge) }
+    desc 'Launch Edge (headless)'
+    task(:headless) { dvla_browser_launch(:headless_selenium_edge) }
+    desc 'Launch Edge (no JS)'
+    task(:no_js) { dvla_browser_launch(:selenium_edge_no_js) }
+    desc 'Launch Edge (headless, no JS)'
+    task(:headless_no_js) { dvla_browser_launch(:headless_selenium_edge_no_js) }
+    desc 'Launch Edge (proxied)'
+    task(:proxied) { dvla_browser_launch(:selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Edge (headless, proxied)'
+    task(:headless_proxied) { dvla_browser_launch(:headless_selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Edge (headless, no JS, proxied)'
+    task(:headless_no_js_proxied) { dvla_browser_launch(:headless_selenium_edge_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Edge with mobile emulation'
+    task(:emulated) { dvla_browser_launch(:selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    desc 'Launch Edge (headless) with mobile emulation'
+    task(:headless_emulated)    { dvla_browser_launch(:headless_selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    desc "Launch Edge at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:window_size)          { dvla_browser_launch(:selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    desc "Launch Edge (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:headless_window_size) { dvla_browser_launch(:headless_selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  end
 
   # ── Selenium Safari ───────────────────────────────────────────────────────────
 
-  task(:selenium_safari) { dvla_browser_launch(:selenium_safari) }
+  desc 'Launch Safari'
+  task(safari: 'browser:safari:default')
+
+  namespace :safari do
+    desc 'Launch Safari'
+    task(:default) { dvla_browser_launch(:selenium_safari) }
+  end
 
   # ── Cuprite ───────────────────────────────────────────────────────────────────
 
-  task(:cuprite)                          { dvla_browser_launch(:cuprite) }
-  task(:headless_cuprite)                 { dvla_browser_launch(:headless_cuprite) }
-  task(:cuprite_no_js)                    { dvla_browser_launch(:cuprite_no_js) }
-  task(:headless_cuprite_no_js)           { dvla_browser_launch(:headless_cuprite_no_js) }
-  task(:cuprite_proxied)                  { dvla_browser_launch(:cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_cuprite_proxied)         { dvla_browser_launch(:headless_cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_cuprite_no_js_proxied)   { dvla_browser_launch(:headless_cuprite_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:cuprite_window_size)              { dvla_browser_launch(:cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-  task(:headless_cuprite_window_size)     { dvla_browser_launch(:headless_cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  desc 'Launch Cuprite'
+  task(cuprite: 'browser:cuprite:default')
+
+  namespace :cuprite do
+    desc 'Launch Cuprite'
+    task(:default) { dvla_browser_launch(:cuprite) }
+    desc 'Launch Cuprite (headless)'
+    task(:headless) { dvla_browser_launch(:headless_cuprite) }
+    desc 'Launch Cuprite (no JS)'
+    task(:no_js) { dvla_browser_launch(:cuprite_no_js) }
+    desc 'Launch Cuprite (headless, no JS)'
+    task(:headless_no_js) { dvla_browser_launch(:headless_cuprite_no_js) }
+    desc 'Launch Cuprite (proxied)'
+    task(:proxied) { dvla_browser_launch(:cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Cuprite (headless, proxied)'
+    task(:headless_proxied) { dvla_browser_launch(:headless_cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Cuprite (headless, no JS, proxied)'
+    task(:headless_no_js_proxied) { dvla_browser_launch(:headless_cuprite_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc "Launch Cuprite at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:window_size) { dvla_browser_launch(:cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    desc "Launch Cuprite (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:headless_window_size) { dvla_browser_launch(:headless_cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  end
 
   # ── Apparition ────────────────────────────────────────────────────────────────
 
-  task(:apparition)                           { dvla_browser_launch(:apparition) }
-  task(:headless_apparition)                  { dvla_browser_launch(:headless_apparition) }
-  task(:apparition_no_js)                     { dvla_browser_launch(:apparition_no_js) }
-  task(:headless_apparition_no_js)            { dvla_browser_launch(:headless_apparition_no_js) }
-  task(:apparition_proxied)                   { dvla_browser_launch(:apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_apparition_proxied)          { dvla_browser_launch(:headless_apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_apparition_no_js_proxied)    { dvla_browser_launch(:headless_apparition_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:apparition_window_size)               { dvla_browser_launch(:apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-  task(:headless_apparition_window_size)      { dvla_browser_launch(:headless_apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  desc 'Launch Apparition'
+  task(apparition: 'browser:apparition:default')
+
+  namespace :apparition do
+    desc 'Launch Apparition'
+    task(:default) { dvla_browser_launch(:apparition) }
+    desc 'Launch Apparition (headless)'
+    task(:headless)             { dvla_browser_launch(:headless_apparition) }
+    desc 'Launch Apparition (no JS)'
+    task(:no_js)                { dvla_browser_launch(:apparition_no_js) }
+    desc 'Launch Apparition (headless, no JS)'
+    task(:headless_no_js) { dvla_browser_launch(:headless_apparition_no_js) }
+    desc 'Launch Apparition (proxied)'
+    task(:proxied) { dvla_browser_launch(:apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Apparition (headless, proxied)'
+    task(:headless_proxied) { dvla_browser_launch(:headless_apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc 'Launch Apparition (headless, no JS, proxied)'
+    task(:headless_no_js_proxied) { dvla_browser_launch(:headless_apparition_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    desc "Launch Apparition at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:window_size) { dvla_browser_launch(:apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    desc "Launch Apparition (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+    task(:headless_window_size) { dvla_browser_launch(:headless_apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  end
 
   # ── Playwright ────────────────────────────────────────────────────────────────
 
-  task(:playwright_chromium)                  { dvla_browser_launch(:playwright_chromium) }
-  task(:headless_playwright_chromium)         { dvla_browser_launch(:headless_playwright_chromium) }
-  task(:playwright_chromium_proxied)          { dvla_browser_launch(:playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_playwright_chromium_proxied) { dvla_browser_launch(:headless_playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:playwright_chromium_window_size)      { dvla_browser_launch(:playwright_chromium, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  namespace :playwright do
+    desc 'Launch Playwright Chromium'
+    task(chromium: 'browser:playwright:chromium:default')
+    desc 'Launch Playwright Firefox'
+    task(firefox: 'browser:playwright:firefox:default')
+    desc 'Launch Playwright WebKit'
+    task(webkit: 'browser:playwright:webkit:default')
 
-  task(:playwright_firefox)                   { dvla_browser_launch(:playwright_firefox) }
-  task(:headless_playwright_firefox)          { dvla_browser_launch(:headless_playwright_firefox) }
-  task(:playwright_firefox_proxied)           { dvla_browser_launch(:playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_playwright_firefox_proxied)  { dvla_browser_launch(:headless_playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    namespace :chromium do
+      desc 'Launch Playwright Chromium'
+      task(:default)          { dvla_browser_launch(:playwright_chromium) }
+      desc 'Launch Playwright Chromium (headless)'
+      task(:headless)         { dvla_browser_launch(:headless_playwright_chromium) }
+      desc 'Launch Playwright Chromium (proxied)'
+      task(:proxied)          { dvla_browser_launch(:playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+      desc 'Launch Playwright Chromium (headless, proxied)'
+      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+      desc "Launch Playwright Chromium at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
+      task(:window_size)      { dvla_browser_launch(:playwright_chromium, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+    end
 
-  task(:playwright_webkit)                    { dvla_browser_launch(:playwright_webkit) }
-  task(:headless_playwright_webkit)           { dvla_browser_launch(:headless_playwright_webkit) }
-  task(:playwright_webkit_proxied)            { dvla_browser_launch(:playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-  task(:headless_playwright_webkit_proxied)   { dvla_browser_launch(:headless_playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    namespace :firefox do
+      desc 'Launch Playwright Firefox'
+      task(:default)          { dvla_browser_launch(:playwright_firefox) }
+      desc 'Launch Playwright Firefox (headless)'
+      task(:headless)         { dvla_browser_launch(:headless_playwright_firefox) }
+      desc 'Launch Playwright Firefox (proxied)'
+      task(:proxied)          { dvla_browser_launch(:playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+      desc 'Launch Playwright Firefox (headless, proxied)'
+      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    end
+
+    namespace :webkit do
+      desc 'Launch Playwright WebKit'
+      task(:default)          { dvla_browser_launch(:playwright_webkit) }
+      desc 'Launch Playwright WebKit (headless)'
+      task(:headless)         { dvla_browser_launch(:headless_playwright_webkit) }
+      desc 'Launch Playwright WebKit (proxied)'
+      task(:proxied)          { dvla_browser_launch(:playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+      desc 'Launch Playwright WebKit (headless, proxied)'
+      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+    end
+  end
 end

--- a/lib/dvla/browser/drivers/tasks/browser.rake
+++ b/lib/dvla/browser/drivers/tasks/browser.rake
@@ -165,49 +165,4 @@ namespace :browser do
     task(:headless_window_size) { dvla_browser_launch(:headless_apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
   end
 
-  # ── Playwright ────────────────────────────────────────────────────────────────
-
-  namespace :playwright do
-    desc 'Launch Playwright Chromium'
-    task(chromium: 'browser:playwright:chromium:default')
-    desc 'Launch Playwright Firefox'
-    task(firefox: 'browser:playwright:firefox:default')
-    desc 'Launch Playwright WebKit'
-    task(webkit: 'browser:playwright:webkit:default')
-
-    namespace :chromium do
-      desc 'Launch Playwright Chromium'
-      task(:default)          { dvla_browser_launch(:playwright_chromium) }
-      desc 'Launch Playwright Chromium (headless)'
-      task(:headless)         { dvla_browser_launch(:headless_playwright_chromium) }
-      desc 'Launch Playwright Chromium (proxied)'
-      task(:proxied)          { dvla_browser_launch(:playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-      desc 'Launch Playwright Chromium (headless, proxied)'
-      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-      desc "Launch Playwright Chromium at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
-      task(:window_size)      { dvla_browser_launch(:playwright_chromium, window_size: DVLA_BROWSER_WINDOW_SIZE) }
-    end
-
-    namespace :firefox do
-      desc 'Launch Playwright Firefox'
-      task(:default)          { dvla_browser_launch(:playwright_firefox) }
-      desc 'Launch Playwright Firefox (headless)'
-      task(:headless)         { dvla_browser_launch(:headless_playwright_firefox) }
-      desc 'Launch Playwright Firefox (proxied)'
-      task(:proxied)          { dvla_browser_launch(:playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-      desc 'Launch Playwright Firefox (headless, proxied)'
-      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-    end
-
-    namespace :webkit do
-      desc 'Launch Playwright WebKit'
-      task(:default)          { dvla_browser_launch(:playwright_webkit) }
-      desc 'Launch Playwright WebKit (headless)'
-      task(:headless)         { dvla_browser_launch(:headless_playwright_webkit) }
-      desc 'Launch Playwright WebKit (proxied)'
-      task(:proxied)          { dvla_browser_launch(:playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-      desc 'Launch Playwright WebKit (headless, proxied)'
-      task(:headless_proxied) { dvla_browser_launch(:headless_playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
-    end
-  end
 end

--- a/lib/dvla/browser/drivers/tasks/browser.rake
+++ b/lib/dvla/browser/drivers/tasks/browser.rake
@@ -1,0 +1,106 @@
+require 'capybara'
+require 'dvla/browser/drivers'
+
+DVLA_BROWSER_URL         = ENV.fetch('BROWSER_URL', 'http://localhost:3000').freeze
+DVLA_BROWSER_PROXY_URL   = ENV.fetch('PROXY_URL', 'http://localhost:8080').freeze
+DVLA_BROWSER_OPEN_TIME   = ENV.fetch('BROWSER_OPEN_TIME', 10).to_i
+DVLA_BROWSER_WINDOW_SIZE = ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800').then { |s| s.split('x').map(&:to_i) }.freeze
+DVLA_BROWSER_MOBILE_PROFILES = DVLA::Browser::Drivers::MOBILE_PROFILES.keys
+
+def dvla_browser_launch(driver_name, **)
+  DVLA::Browser::Drivers.send(driver_name, **)
+  session = Capybara::Session.new(driver_name)
+  session.visit(DVLA_BROWSER_URL)
+  sleep DVLA_BROWSER_OPEN_TIME
+  # binding.irb
+ensure
+  session.quit
+end
+
+namespace :browser do
+  # ── Selenium Chrome ───────────────────────────────────────────────────────────
+
+  task(:selenium_chrome)                        { dvla_browser_launch(:selenium_chrome) }
+  task(:headless_selenium_chrome)               { dvla_browser_launch(:headless_selenium_chrome) }
+  task(:selenium_chrome_no_js)                  { dvla_browser_launch(:selenium_chrome_no_js) }
+  task(:headless_selenium_chrome_no_js)         { dvla_browser_launch(:headless_selenium_chrome_no_js) }
+  task(:selenium_chrome_proxied)                { dvla_browser_launch(:selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_chrome_proxied)       { dvla_browser_launch(:headless_selenium_chrome_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_chrome_no_js_proxied) { dvla_browser_launch(:headless_selenium_chrome_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:selenium_chrome_emulated)               { dvla_browser_launch(:selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+  task(:headless_selenium_chrome_emulated)      { dvla_browser_launch(:headless_selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+  task(:selenium_chrome_window_size)            { dvla_browser_launch(:selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  task(:headless_selenium_chrome_window_size)   { dvla_browser_launch(:headless_selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  # ── Selenium Firefox ──────────────────────────────────────────────────────────
+
+  task(:selenium_firefox)                             { dvla_browser_launch(:selenium_firefox) }
+  task(:headless_selenium_firefox)                    { dvla_browser_launch(:headless_selenium_firefox) }
+  task(:selenium_firefox_no_js)                       { dvla_browser_launch(:selenium_firefox_no_js) }
+  task(:headless_selenium_firefox_no_js)              { dvla_browser_launch(:headless_selenium_firefox_no_js) }
+  task(:selenium_firefox_proxied)                     { dvla_browser_launch(:selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_firefox_proxied)            { dvla_browser_launch(:headless_selenium_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_firefox_no_js_proxied)      { dvla_browser_launch(:headless_selenium_firefox_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:selenium_firefox_window_size)                 { dvla_browser_launch(:selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  task(:headless_selenium_firefox_window_size)        { dvla_browser_launch(:headless_selenium_firefox, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  # ── Selenium Edge ─────────────────────────────────────────────────────────────
+
+  task(:selenium_edge)                          { dvla_browser_launch(:selenium_edge) }
+  task(:headless_selenium_edge)                 { dvla_browser_launch(:headless_selenium_edge) }
+  task(:selenium_edge_no_js)                    { dvla_browser_launch(:selenium_edge_no_js) }
+  task(:headless_selenium_edge_no_js)           { dvla_browser_launch(:headless_selenium_edge_no_js) }
+  task(:selenium_edge_proxied)                  { dvla_browser_launch(:selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_edge_proxied)         { dvla_browser_launch(:headless_selenium_edge_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_selenium_edge_no_js_proxied)   { dvla_browser_launch(:headless_selenium_edge_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:selenium_edge_emulated)                 { dvla_browser_launch(:selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+  task(:headless_selenium_edge_emulated)        { dvla_browser_launch(:headless_selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+  task(:selenium_edge_window_size)              { dvla_browser_launch(:selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  task(:headless_selenium_edge_window_size)     { dvla_browser_launch(:headless_selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  # ── Selenium Safari ───────────────────────────────────────────────────────────
+
+  task(:selenium_safari) { dvla_browser_launch(:selenium_safari) }
+
+  # ── Cuprite ───────────────────────────────────────────────────────────────────
+
+  task(:cuprite)                          { dvla_browser_launch(:cuprite) }
+  task(:headless_cuprite)                 { dvla_browser_launch(:headless_cuprite) }
+  task(:cuprite_no_js)                    { dvla_browser_launch(:cuprite_no_js) }
+  task(:headless_cuprite_no_js)           { dvla_browser_launch(:headless_cuprite_no_js) }
+  task(:cuprite_proxied)                  { dvla_browser_launch(:cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_cuprite_proxied)         { dvla_browser_launch(:headless_cuprite_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_cuprite_no_js_proxied)   { dvla_browser_launch(:headless_cuprite_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:cuprite_window_size)              { dvla_browser_launch(:cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  task(:headless_cuprite_window_size)     { dvla_browser_launch(:headless_cuprite, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  # ── Apparition ────────────────────────────────────────────────────────────────
+
+  task(:apparition)                           { dvla_browser_launch(:apparition) }
+  task(:headless_apparition)                  { dvla_browser_launch(:headless_apparition) }
+  task(:apparition_no_js)                     { dvla_browser_launch(:apparition_no_js) }
+  task(:headless_apparition_no_js)            { dvla_browser_launch(:headless_apparition_no_js) }
+  task(:apparition_proxied)                   { dvla_browser_launch(:apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_apparition_proxied)          { dvla_browser_launch(:headless_apparition_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_apparition_no_js_proxied)    { dvla_browser_launch(:headless_apparition_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:apparition_window_size)               { dvla_browser_launch(:apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+  task(:headless_apparition_window_size)      { dvla_browser_launch(:headless_apparition, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  # ── Playwright ────────────────────────────────────────────────────────────────
+
+  task(:playwright_chromium)                  { dvla_browser_launch(:playwright_chromium) }
+  task(:headless_playwright_chromium)         { dvla_browser_launch(:headless_playwright_chromium) }
+  task(:playwright_chromium_proxied)          { dvla_browser_launch(:playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_playwright_chromium_proxied) { dvla_browser_launch(:headless_playwright_chromium_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:playwright_chromium_window_size)      { dvla_browser_launch(:playwright_chromium, window_size: DVLA_BROWSER_WINDOW_SIZE) }
+
+  task(:playwright_firefox)                   { dvla_browser_launch(:playwright_firefox) }
+  task(:headless_playwright_firefox)          { dvla_browser_launch(:headless_playwright_firefox) }
+  task(:playwright_firefox_proxied)           { dvla_browser_launch(:playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_playwright_firefox_proxied)  { dvla_browser_launch(:headless_playwright_firefox_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+
+  task(:playwright_webkit)                    { dvla_browser_launch(:playwright_webkit) }
+  task(:headless_playwright_webkit)           { dvla_browser_launch(:headless_playwright_webkit) }
+  task(:playwright_webkit_proxied)            { dvla_browser_launch(:playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+  task(:headless_playwright_webkit_proxied)   { dvla_browser_launch(:headless_playwright_webkit_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
+end

--- a/lib/dvla/browser/drivers/tasks/browser.rake
+++ b/lib/dvla/browser/drivers/tasks/browser.rake
@@ -38,9 +38,9 @@ namespace :browser do
     desc 'Launch Chrome (headless, no JS, proxied)'
     task(:headless_no_js_proxied) { dvla_browser_launch(:headless_selenium_chrome_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
     desc 'Launch Chrome with mobile emulation'
-    task(:emulated) { dvla_browser_launch(:selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    task(:emulated) { dvla_browser_launch(:selenium_chrome, emulate_device: DVLA_BROWSER_MOBILE_PROFILES.sample) }
     desc 'Launch Chrome (headless) with mobile emulation'
-    task(:headless_emulated) { dvla_browser_launch(:headless_selenium_chrome, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    task(:headless_emulated) { dvla_browser_launch(:headless_selenium_chrome, emulate_device: DVLA_BROWSER_MOBILE_PROFILES.sample) }
     desc "Launch Chrome at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
     task(:window_size) { dvla_browser_launch(:selenium_chrome, window_size: DVLA_BROWSER_WINDOW_SIZE) }
     desc "Launch Chrome (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
@@ -94,9 +94,9 @@ namespace :browser do
     desc 'Launch Edge (headless, no JS, proxied)'
     task(:headless_no_js_proxied) { dvla_browser_launch(:headless_selenium_edge_no_js_proxied, proxy: DVLA_BROWSER_PROXY_URL) }
     desc 'Launch Edge with mobile emulation'
-    task(:emulated) { dvla_browser_launch(:selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    task(:emulated) { dvla_browser_launch(:selenium_edge, emulate_device: DVLA_BROWSER_MOBILE_PROFILES.sample) }
     desc 'Launch Edge (headless) with mobile emulation'
-    task(:headless_emulated)    { dvla_browser_launch(:headless_selenium_edge, mobile_emulation: DVLA_BROWSER_MOBILE_PROFILES.sample) }
+    task(:headless_emulated)    { dvla_browser_launch(:headless_selenium_edge, emulate_device: DVLA_BROWSER_MOBILE_PROFILES.sample) }
     desc "Launch Edge at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"
     task(:window_size)          { dvla_browser_launch(:selenium_edge, window_size: DVLA_BROWSER_WINDOW_SIZE) }
     desc "Launch Edge (headless) at window size #{ENV.fetch('BROWSER_WINDOW_SIZE', '1337x800')}"

--- a/lib/dvla/browser/drivers/version.rb
+++ b/lib/dvla/browser/drivers/version.rb
@@ -3,7 +3,7 @@
 module DVLA
   module Browser
     module Drivers
-      VERSION = '3.2.0'
+      VERSION = '3.3.0'
     end
   end
 end

--- a/playground/README.md
+++ b/playground/README.md
@@ -2,4 +2,16 @@ For testing browsers locally
 
 Run a simple file server and proxy from the top level using: `ruby playground/servers.rb`
 
-Then use the rake tasks to try them out: `bundle exec rake browser:selenium_chrome`
+Available rake tasks can be found by running:
+`bundle exec rake --tasks browser`
+
+Each task will just open the browser and close after a few seconds
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BROWSER_URL` | `http://localhost:3000` | URL the browser will open |
+| `PROXY_URL` | `http://localhost:8080` | Proxy URL for `proxied` tasks |
+| `BROWSER_OPEN_TIME` | `10` | Seconds to hold the browser open |
+| `BROWSER_WINDOW_SIZE` | `1337x800` | Window size for `window_size` tasks |

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,5 @@
+For testing browsers locally
+
+Run a simple file server and proxy from the top level using: `ruby playground/servers.rb`
+
+Then use the rake tasks to try them out: `bundle exec rake browser:selenium_chrome`

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,55 +3,209 @@
 <head>
   <meta charset="UTF-8">
   <title>Browser Info</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; display: flex; flex-wrap: wrap; gap: 2rem; align-items: flex-start; }
+    h2 { margin: 0 0 0.5rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: #999; }
+    table { border-collapse: collapse; }
+    td { padding: 0.4rem 1rem; border-bottom: 1px solid #ddd; }
+    td:first-child { color: #555; }
+  </style>
 </head>
 <body>
-  <p id="browser">Browser: unknown</p>
-  <p id="js">Javascript enabled: false</p>
-  <p id="ua">User Agent: unknown</p>
-  <p id="webdriver">Webdriver: unknown</p>
-  <p id="size_inner">Inner Size: unknown</p>
-  <p id="size_outer">Outer Size: unknown</p>
-  <p id="resolution">Screen Resolution: unknown</p>
-  <p id="orientation">Screen Orientation: unknown</p>
-  <p id="cores">Number of Cores: unknown</p>
-  <p id="touch">Touchscreen Enabled: unknown</p>
-  <p id="cookies">Cookies Enabled: unknown</p>
-  <p id="local_storage">Local Storage: unknown</p>
-  <p id="session_storage">Session Storage: unknown</p>
-  <p id="history">History Entries: unknown</p>
-  <p id="referrer">Referrer: unknown</p>
-  <p id="graphics">Graphics Card: unknown</p>
-  <p id="private">Private Browsing: unknown</p>
-
+<div>
+  <section>
+    <h2>Browser</h2>
+    <table><tbody>
+      <tr><td>Browser</td><td><strong id="browser">unknown</strong></td></tr>
+      <tr><td>User Agent</td><td><strong id="ua">unknown</strong></td></tr>
+      <tr><td>Platform</td><td><strong id="platform">unknown</strong></td></tr>
+      <tr><td>Vendor</td><td><strong id="vendor">unknown</strong></td></tr>
+      <tr><td>Language</td><td><strong id="language">unknown</strong></td></tr>
+      <tr><td>Timezone</td><td><strong id="timezone">unknown</strong></td></tr>
+      <tr><td>Locale</td><td><strong id="locale">unknown</strong></td></tr>
+      <tr><td>Javascript Enabled</td><td><strong id="js">false</strong></td></tr>
+      <tr><td>Webdriver</td><td><strong id="webdriver">unknown</strong></td></tr>
+      <tr><td>PDF Viewer Enabled</td><td><strong id="pdf_viewer">unknown</strong></td></tr>
+      <tr><td>Plugins</td><td><strong id="plugins">unknown</strong></td></tr>
+      <tr><td>MIME Types</td><td><strong id="mime_types">unknown</strong></td></tr>
+      <tr><td>window.chrome</td><td><strong id="window_chrome">unknown</strong></td></tr>
+      <tr><td>Private Browsing</td><td><strong id="private">unknown</strong></td></tr>
+      <tr><td>Do Not Track</td><td><strong id="dnt">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+<br>
+  <section>
+    <h2>Display</h2>
+    <table><tbody>
+      <tr><td>Inner Size</td><td><strong id="size_inner">unknown</strong></td></tr>
+      <tr><td>Outer Size</td><td><strong id="size_outer">unknown</strong></td></tr>
+      <tr><td>Screen Resolution</td><td><strong id="resolution">unknown</strong></td></tr>
+      <tr><td>Available Screen</td><td><strong id="avail_screen">unknown</strong></td></tr>
+      <tr><td>Screen Orientation</td><td><strong id="orientation">unknown</strong></td></tr>
+      <tr><td>Device Pixel Ratio</td><td><strong id="pixel_ratio">unknown</strong></td></tr>
+      <tr><td>Colour Depth</td><td><strong id="colour_depth">unknown</strong></td></tr>
+      <tr><td>Scroll Position</td><td><strong id="scroll">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Hardware</h2>
+    <table><tbody>
+      <tr><td>Number of Cores</td><td><strong id="cores">unknown</strong></td></tr>
+      <tr><td>Device Memory (GB)</td><td><strong id="memory">unknown</strong></td></tr>
+      <tr><td>Touchscreen Enabled</td><td><strong id="touch">unknown</strong></td></tr>
+      <tr><td>Graphics Card</td><td><strong id="graphics">unknown</strong></td></tr>
+      <tr><td>Battery Charging</td><td><strong id="battery_charging">unknown</strong></td></tr>
+      <tr><td>Battery Level</td><td><strong id="battery_level">unknown</strong></td></tr>
+      <tr><td>Bluetooth Available</td><td><strong id="bluetooth">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Storage &amp; Network</h2>
+    <table><tbody>
+      <tr><td>Cookies Enabled</td><td><strong id="cookies">unknown</strong></td></tr>
+      <tr><td>Cookie Writable</td><td><strong id="cookie_write">unknown</strong></td></tr>
+      <tr><td>Local Storage</td><td><strong id="local_storage">unknown</strong></td></tr>
+      <tr><td>Session Storage</td><td><strong id="session_storage">unknown</strong></td></tr>
+      <tr><td>Online</td><td><strong id="online">unknown</strong></td></tr>
+      <tr><td>Connection Type</td><td><strong id="connection">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Permissions</h2>
+    <table><tbody>
+      <tr><td>Notifications</td><td><strong id="perm_notifications">unknown</strong></td></tr>
+      <tr><td>Geolocation</td><td><strong id="perm_geolocation">unknown</strong></td></tr>
+      <tr><td>Camera</td><td><strong id="perm_camera">unknown</strong></td></tr>
+      <tr><td>Microphone</td><td><strong id="perm_microphone">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Security</h2>
+    <table><tbody>
+      <tr><td>crypto.randomUUID</td><td><strong id="crypto_uuid">unknown</strong></td></tr>
+      <tr><td>window.opener</td><td><strong id="opener">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Performance</h2>
+    <table><tbody>
+      <tr><td>Navigation Type</td><td><strong id="nav_type">unknown</strong></td></tr>
+      <tr><td>JS Heap Size Limit</td><td><strong id="heap_limit">unknown</strong></td></tr>
+      <tr><td>JS Heap Used</td><td><strong id="heap_used">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  <br>
+  <section>
+    <h2>Navigation</h2>
+    <table><tbody>
+      <tr><td>History Entries</td><td><strong id="history">unknown</strong></td></tr>
+      <tr><td>Referrer</td><td><strong id="referrer">unknown</strong></td></tr>
+      <tr><td>Current URL</td><td><strong id="url">unknown</strong></td></tr>
+    </tbody></table>
+  </section>
+  </div>
+  <br>
   <script>
-    const ua = navigator.userAgent;
-    const browser = navigator.userAgentData?.brands.map(b => b.brand).join(', ') ?? 'unknown';
+    const set = (id, val) => document.getElementById(id).textContent = val;
+    const mb = bytes => `${(bytes / 1048576).toFixed(1)} MB`;
+    const navTypes = ['navigate', 'reload', 'back_forward', 'prerender'];
 
-    document.getElementById('browser').textContent = `Browser: ${browser}`;
-    document.getElementById('js').textContent = 'Javascript enabled: true';
-    document.getElementById('ua').textContent = `User Agent: ${ua}`;
-    document.getElementById('webdriver').textContent = `Webdriver: ${navigator.webdriver}`;
-    document.getElementById('size_inner').textContent = `Inner Size: ${window.innerWidth}x${window.innerHeight}`;
-    document.getElementById('size_outer').textContent = `Outer Size: ${window.outerWidth}x${window.outerHeight}`;
-    document.getElementById('resolution').textContent = `Screen Resolution: ${screen.width}x${screen.height}`;
-    document.getElementById('orientation').textContent = `Screen Orientation: ${screen.orientation?.type ?? 'unknown'}`;
-    document.getElementById('cores').textContent = `Number of Cores: ${navigator.hardwareConcurrency}`;
-    document.getElementById('touch').textContent = `Touchscreen Enabled: ${navigator.maxTouchPoints > 0}`;
-    document.getElementById('cookies').textContent = `Cookies Enabled: ${navigator.cookieEnabled}`;
-    document.getElementById('history').textContent = `History Entries: ${history.length}`;
-    document.getElementById('referrer').textContent = `Referrer: ${document.referrer || 'none'}`;
+    // Browser
+    set('browser', navigator.userAgentData?.brands.map(b => b.brand).join(', ') ?? 'unknown');
+    set('ua', navigator.userAgent);
+    set('platform', navigator.userAgentData?.platform ?? navigator.platform ?? 'unknown');
+    set('vendor', navigator.vendor || 'none');
+    set('language', navigator.language);
+    set('timezone', Intl.DateTimeFormat().resolvedOptions().timeZone);
+    set('locale', Intl.DateTimeFormat().resolvedOptions().locale);
+    set('js', 'true');
+    set('webdriver', navigator.webdriver);
+    set('pdf_viewer', navigator.pdfViewerEnabled ?? 'unknown');
+    set('plugins', navigator.plugins.length);
+    set('mime_types', navigator.mimeTypes.length);
+    set('window_chrome', 'chrome' in window ? 'present' : 'absent');
+    set('dnt', navigator.doNotTrack ?? 'unknown');
 
-    try { localStorage.getItem(''); document.getElementById('local_storage').textContent = 'Local Storage: true'; }
-    catch { document.getElementById('local_storage').textContent = 'Local Storage: false'; }
+    // Display
+    set('size_inner', `${window.innerWidth}x${window.innerHeight}`);
+    set('size_outer', `${window.outerWidth}x${window.outerHeight}`);
+    set('resolution', `${screen.width}x${screen.height}`);
+    set('avail_screen', `${screen.availWidth}x${screen.availHeight}`);
+    set('orientation', screen.orientation?.type ?? 'unknown');
+    set('pixel_ratio', window.devicePixelRatio);
+    set('colour_depth', `${screen.colorDepth}-bit`);
+    set('scroll', `${window.scrollX}x${window.scrollY}`);
 
-    try { sessionStorage.getItem(''); document.getElementById('session_storage').textContent = 'Session Storage: true'; }
-    catch { document.getElementById('session_storage').textContent = 'Session Storage: false'; }
+    // Hardware
+    set('cores', navigator.hardwareConcurrency);
+    set('memory', navigator.deviceMemory ?? 'unknown');
+    set('touch', navigator.maxTouchPoints > 0);
+    set('bluetooth', 'bluetooth' in navigator ? 'available' : 'unavailable');
 
     try {
       const gl = document.createElement('canvas').getContext('webgl');
       const ext = gl.getExtension('WEBGL_debug_renderer_info');
-      document.getElementById('graphics').textContent = `Graphics Card: ${ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : 'unavailable'}`;
-    } catch { document.getElementById('graphics').textContent = 'Graphics Card: unavailable'; }
+      set('graphics', ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : 'unavailable');
+    } catch { set('graphics', 'unavailable'); }
+
+    navigator.getBattery?.().then(b => {
+      set('battery_charging', b.charging);
+      set('battery_level', `${Math.round(b.level * 100)}%`);
+    }).catch(() => { set('battery_charging', 'unavailable'); set('battery_level', 'unavailable'); });
+
+    // Storage & Network
+    set('cookies', navigator.cookieEnabled);
+    try {
+      document.cookie = '_test=1';
+      set('cookie_write', document.cookie.includes('_test') ? 'true' : 'false');
+      document.cookie = '_test=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    } catch { set('cookie_write', 'false'); }
+
+    try { localStorage.getItem(''); set('local_storage', 'true'); }
+    catch { set('local_storage', 'false'); }
+
+    try { sessionStorage.getItem(''); set('session_storage', 'true'); }
+    catch { set('session_storage', 'false'); }
+
+    set('online', navigator.onLine);
+    set('connection', navigator.connection?.effectiveType ?? 'unknown');
+
+    // Permissions
+    const queryPerm = (name, id) =>
+      navigator.permissions?.query({ name }).then(r => set(id, r.state)).catch(() => set(id, 'unavailable'));
+    queryPerm('notifications', 'perm_notifications');
+    queryPerm('geolocation', 'perm_geolocation');
+    queryPerm('camera', 'perm_camera');
+    queryPerm('microphone', 'perm_microphone');
+
+    // Security
+    set('crypto_uuid', typeof crypto?.randomUUID === 'function' ? 'available' : 'unavailable');
+    set('opener', window.opener === null ? 'null' : 'set');
+
+    // Performance
+    const navEntry = performance.getEntriesByType('navigation')[0];
+    set('nav_type', navEntry?.type ?? navTypes[performance.navigation?.type] ?? 'unknown');
+    if (performance.memory) {
+      set('heap_limit', mb(performance.memory.jsHeapSizeLimit));
+      set('heap_used', mb(performance.memory.usedJSHeapSize));
+    } else {
+      set('heap_limit', 'unavailable'); set('heap_used', 'unavailable');
+    }
+
+    // Navigation
+    set('history', history.length);
+    set('referrer', document.referrer || 'none');
+    set('url', location.href);
+
+    // Private browsing heuristic
+    navigator.storage?.estimate?.().then(({ quota }) =>
+      set('private', quota < 120000000 ? 'likely' : 'unlikely')
+    ).catch(() => set('private', 'unknown'));
   </script>
 </body>
 </html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Browser Info</title>
+</head>
+<body>
+  <p id="browser">Browser: unknown</p>
+  <p id="js">Javascript enabled: false</p>
+  <p id="ua">User Agent: unknown</p>
+  <p id="webdriver">Webdriver: unknown</p>
+  <p id="size_inner">Inner Size: unknown</p>
+  <p id="size_outer">Outer Size: unknown</p>
+  <p id="resolution">Screen Resolution: unknown</p>
+  <p id="orientation">Screen Orientation: unknown</p>
+  <p id="cores">Number of Cores: unknown</p>
+  <p id="touch">Touchscreen Enabled: unknown</p>
+  <p id="cookies">Cookies Enabled: unknown</p>
+  <p id="local_storage">Local Storage: unknown</p>
+  <p id="session_storage">Session Storage: unknown</p>
+  <p id="history">History Entries: unknown</p>
+  <p id="referrer">Referrer: unknown</p>
+  <p id="graphics">Graphics Card: unknown</p>
+  <p id="private">Private Browsing: unknown</p>
+
+  <script>
+    const ua = navigator.userAgent;
+    const browser = navigator.userAgentData?.brands.map(b => b.brand).join(', ') ?? 'unknown';
+
+    document.getElementById('browser').textContent = `Browser: ${browser}`;
+    document.getElementById('js').textContent = 'Javascript enabled: true';
+    document.getElementById('ua').textContent = `User Agent: ${ua}`;
+    document.getElementById('webdriver').textContent = `Webdriver: ${navigator.webdriver}`;
+    document.getElementById('size_inner').textContent = `Inner Size: ${window.innerWidth}x${window.innerHeight}`;
+    document.getElementById('size_outer').textContent = `Outer Size: ${window.outerWidth}x${window.outerHeight}`;
+    document.getElementById('resolution').textContent = `Screen Resolution: ${screen.width}x${screen.height}`;
+    document.getElementById('orientation').textContent = `Screen Orientation: ${screen.orientation?.type ?? 'unknown'}`;
+    document.getElementById('cores').textContent = `Number of Cores: ${navigator.hardwareConcurrency}`;
+    document.getElementById('touch').textContent = `Touchscreen Enabled: ${navigator.maxTouchPoints > 0}`;
+    document.getElementById('cookies').textContent = `Cookies Enabled: ${navigator.cookieEnabled}`;
+    document.getElementById('history').textContent = `History Entries: ${history.length}`;
+    document.getElementById('referrer').textContent = `Referrer: ${document.referrer || 'none'}`;
+
+    try { localStorage.getItem(''); document.getElementById('local_storage').textContent = 'Local Storage: true'; }
+    catch { document.getElementById('local_storage').textContent = 'Local Storage: false'; }
+
+    try { sessionStorage.getItem(''); document.getElementById('session_storage').textContent = 'Session Storage: true'; }
+    catch { document.getElementById('session_storage').textContent = 'Session Storage: false'; }
+
+    try {
+      const gl = document.createElement('canvas').getContext('webgl');
+      const ext = gl.getExtension('WEBGL_debug_renderer_info');
+      document.getElementById('graphics').textContent = `Graphics Card: ${ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : 'unavailable'}`;
+    } catch { document.getElementById('graphics').textContent = 'Graphics Card: unavailable'; }
+  </script>
+</body>
+</html>

--- a/playground/servers.rb
+++ b/playground/servers.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+require 'webrick'
+require 'webrick/httpproxy'
+require 'dvla/herodotus'
+
+# Serve our index.html over http to avoid any browser funny business when we visit a file://
+# Run a proxy server on port 8080 to check browsers use it when configured.
+
+class HerodotusWebrickLogger < WEBrick::Log
+  LEVEL_MAP = {
+    WEBrick::Log::DEBUG => :debug,
+    WEBrick::Log::INFO  => :info,
+    WEBrick::Log::WARN  => :warn,
+    WEBrick::Log::ERROR => :error,
+    WEBrick::Log::FATAL => :fatal,
+  }.freeze
+
+  def initialize(herodotus_logger)
+    super(nil)
+    @herodotus = herodotus_logger
+  end
+
+  def log(level, msg)
+    @herodotus.public_send(LEVEL_MAP[level] || :info, msg.strip)
+  end
+end
+
+class HerodotusAccessLog
+  def initialize(herodotus_logger) = @herodotus = herodotus_logger
+
+  def write(msg) = @herodotus.info(msg.strip)
+
+  def <<(msg) = write(msg)
+
+  def flush = nil
+end
+
+def build_logger(name, colour)
+  config = Struct.new(*DVLA::Herodotus::CONFIG_ATTRIBUTES, keyword_init: true).new(
+    prefix_colour: { system: [colour, 'bold'], level: [colour, 'bold'], date: %w[white], time: %w[white] },
+  )
+  DVLA::Herodotus.logger(name, config: config)
+end
+
+web_log   = build_logger('WEB',   'cyan')
+proxy_log = build_logger('PROXY', 'magenta')
+
+access_format = "%h - - [%t] \"%r\" %s %b\n"
+
+web   = WEBrick::HTTPServer.new(Port: 3000, DocumentRoot: __dir__,
+                                Logger: HerodotusWebrickLogger.new(web_log),
+                                AccessLog: [[HerodotusAccessLog.new(web_log), access_format]])
+proxy = WEBrick::HTTPProxyServer.new(Port: 8080,
+                                     Logger: HerodotusWebrickLogger.new(proxy_log),
+                                     AccessLog: [[HerodotusAccessLog.new(proxy_log), access_format]])
+
+trap('INT')  { web.shutdown; proxy.shutdown }
+trap('TERM') { web.shutdown; proxy.shutdown }
+
+[Thread.new { web.start }, Thread.new { proxy.start }].each(&:join)

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -127,17 +127,17 @@ RSpec.describe DVLA::Browser::Drivers do
     end
 
     it 'handles emulation' do
-      DVLA::Browser::Drivers.selenium_chrome(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' })
+      DVLA::Browser::Drivers.selenium_chrome(emulate_device: { 'deviceName' => 'iPhone 14 Pro' })
       expect(Capybara.current_session.driver.options[:options].options[:emulation]).to eq({ deviceName: 'iPhone 14 Pro' })
 
-      DVLA::Browser::Drivers.selenium_edge(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' })
+      DVLA::Browser::Drivers.selenium_edge(emulate_device: { 'deviceName' => 'iPhone 14 Pro' })
       expect(Capybara.current_session.driver.options[:options].options[:emulation]).to eq({ deviceName: 'iPhone 14 Pro' })
     end
 
     it 'warns when both window_size and mobile_emulation are provided' do
       expect do
-        DVLA::Browser::Drivers.selenium_chrome(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' }, window_size: [390, 844])
-      end.to output(/Warning: window_size will be overridden by mobile_emulation/).to_stdout
+        DVLA::Browser::Drivers.selenium_chrome(emulate_device: { 'deviceName' => 'iPhone 14 Pro' }, window_size: [390, 844])
+      end.to output(/Warning: window_size will be overridden by emulate_device/).to_stdout
     end
   end
 

--- a/spec/dvla/browser/drivers_spec.rb
+++ b/spec/dvla/browser/drivers_spec.rb
@@ -125,6 +125,20 @@ RSpec.describe DVLA::Browser::Drivers do
       expect(browser_options[:'proxy-server']).to eq(proxy_url)
       expect(browser_options).to have_key(:'ignore-certificate-errors')
     end
+
+    it 'handles emulation' do
+      DVLA::Browser::Drivers.selenium_chrome(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' })
+      expect(Capybara.current_session.driver.options[:options].options[:emulation]).to eq({ deviceName: 'iPhone 14 Pro' })
+
+      DVLA::Browser::Drivers.selenium_edge(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' })
+      expect(Capybara.current_session.driver.options[:options].options[:emulation]).to eq({ deviceName: 'iPhone 14 Pro' })
+    end
+
+    it 'warns when both window_size and mobile_emulation are provided' do
+      expect do
+        DVLA::Browser::Drivers.selenium_chrome(mobile_emulation: { 'deviceName' => 'iPhone 14 Pro' }, window_size: [390, 844])
+      end.to output(/Warning: window_size will be overridden by mobile_emulation/).to_stdout
+    end
   end
 
   it 'throws a NoMethodError when the method does not match regex' do


### PR DESCRIPTION
* Enabling device emulation for Chrome and Edge via Selenium
* Adding common device emulation configs for ease of use
* Adding window_size arg (ignored if you also use emulation config)
* Break up the giant .method_missing method in meta_drivers.rb
* Added Rake tasks for every major browser configuration.
* Added playground/ directory with simple .html file server and proxy (intended to be used with the rake tasks for manual debugging)